### PR TITLE
May2020 Changes (1 of x): Cleanup ModInfo, Civ6Common, Settings

### DIFF
--- a/Assets/UI/CQUICommon.lua
+++ b/Assets/UI/CQUICommon.lua
@@ -1,0 +1,224 @@
+------------------------------------------------------------------------------
+--  Additional CQUI Common LUA support functions specific to Civilization 6
+--  This file is included by the Civ6Common.lua script
+--  TODO (2020-05): Is it possible to NOT require this be included by the Civ6Common?
+------------------------------------------------------------------------------
+
+-- ===========================================================================
+--  VARIABLES
+-- ===========================================================================
+local CQUI_ShowDebugPrint = false;
+
+-- ===========================================================================
+--CQUI setting control support functions
+-- ===========================================================================
+function print_debug(str)
+  print("ENTRY: CQUICommon - print_debug");
+  if CQUI_ShowDebugPrint then
+    print(str);
+  end
+end
+
+function CQUI_OnSettingsUpdate()
+  print_debug("ENTRY: CQUICommon - CQUI_OnSettingsUpdate");
+  CQUI_ShowDebugPrint = GameConfiguration.GetValue("CQUI_ShowDebugPrint") == 1
+end
+
+-- Used to register a control to be updated whenever settings update (only necessary for controls that can be updated from multiple places)
+function RegisterControl(control, setting_name, update_function, extra_data)
+  print_debug("ENTRY: CQUICommon - RegisterControl");
+  LuaEvents.CQUI_SettingsUpdate.Add(function() update_function(control, setting_name, extra_data); end);
+end
+
+-- Companion functions to RegisterControl
+function UpdateComboBox(control, setting_name, values)
+  -- TODO (2020-05) - is this required?
+end
+
+function UpdateCheckbox(control, setting_name)
+  print_debug("ENTRY: CQUICommon - UpdateCheckbox");
+  local value = GameConfiguration.GetValue(setting_name);
+  if(value == nil) then
+    return;
+  end
+
+  control:SetSelected(value);
+end
+
+function UpdateSlider( control, setting_name, data_converter)
+  print_debug("ENTRY: CQUICommon - UpdateSlider");
+  local value = GameConfiguration.GetValue(setting_name);
+  if(value == nil) then
+    return;
+  end
+
+  control:SetStep(data_converter.ToSteps(value));
+end
+
+--Used to populate combobox options
+function PopulateComboBox(control, values, setting_name, tooltip)
+  print_debug("ENTRY: CQUICommon - PopulateComboBox");
+  control:ClearEntries();
+  local current_value = GameConfiguration.GetValue(setting_name);
+  if(current_value == nil) then
+    --LY Checks if this setting has a default state defined in the database
+    if(GameInfo.CQUI_Settings[setting_name]) then
+      --reads the default value from the database. Set them in Settings.sql
+      current_value = GameInfo.CQUI_Settings[setting_name].Value;
+    else
+      current_value = 0;
+    end
+
+    GameConfiguration.SetValue(setting_name, current_value); --/LY
+  end
+
+  for i, v in ipairs(values) do
+    local instance = {};
+    control:BuildEntry( "InstanceOne", instance );
+    instance.Button:SetVoid1(i);
+    instance.Button:LocalizeAndSetText(v[1]);
+    if(v[2] == current_value) then
+      local button = control:GetButton();
+      button:LocalizeAndSetText(v[1]);
+    end
+  end
+
+  control:CalculateInternals();
+  if(setting_name) then
+    control:RegisterSelectionCallback(
+      function(voidValue1, voidValue2, control)
+        local option = values[voidValue1];
+        local button = control:GetButton();
+        button:LocalizeAndSetText(option[1]);
+        GameConfiguration.SetValue(setting_name, option[2]);
+        LuaEvents.CQUI_SettingsUpdate();
+      end
+    );
+  end
+
+  if(tooltip ~= nil)then
+    control:SetToolTipString(tooltip);
+  end
+end
+
+--Used to populate checkboxes
+function PopulateCheckBox(control, setting_name, tooltip)
+  print_debug("ENTRY: CQUICommon - PopulateCheckBox");
+  local current_value = GameConfiguration.GetValue(setting_name);
+  if(current_value == nil) then
+    --LY Checks if this setting has a default state defined in the database
+    if(GameInfo.CQUI_Settings[setting_name]) then
+      --because 0 is true in Lua
+      if(GameInfo.CQUI_Settings[setting_name].Value == 0) then
+        current_value = false;
+      else
+        current_value = true;
+      end
+    else
+      current_value = false;
+    end
+
+    GameConfiguration.SetValue(setting_name, current_value);
+  end
+
+  if(current_value == false) then
+    control:SetSelected(false);
+  else
+    control:SetSelected(true);
+  end
+
+  control:RegisterCallback(Mouse.eLClick,
+    function()
+      local selected = not control:IsSelected();
+      control:SetSelected(selected);
+      GameConfiguration.SetValue(setting_name, selected);
+      LuaEvents.CQUI_SettingsUpdate();
+    end
+  );
+
+  if(tooltip ~= nil)then
+    control:SetToolTipString(tooltip);
+  end
+end
+
+--Used to populate sliders. data_converter is a table containing two functions: ToStep and ToValue, which describe how to hanlde converting from the incremental slider steps to a setting value, think of it as a less elegant inner class
+--Optional third function: ToString. When included, this function will handle how the value is converted to a display value, otherwise this defaults to using the value from ToValue
+function PopulateSlider(control, label, setting_name, data_converter, tooltip)
+  print_debug("ENTRY: CQUICommon - PopulateSlider");
+  --This is necessary because RegisterSliderCallback fires twice when releasing the mouse cursor for some reason
+  local hasScrolled = false;
+  local current_value = GameConfiguration.GetValue(setting_name);
+  if(current_value == nil) then
+    --LY Checks if this setting has a default state defined in the database
+    if(GameInfo.CQUI_Settings[setting_name]) then
+      current_value = GameInfo.CQUI_Settings[setting_name].Value;
+    else
+      current_value = 0;
+    end
+
+    GameConfiguration.SetValue(setting_name, current_value); --/LY
+  end
+
+  control:SetStep(data_converter.ToSteps(current_value));
+  if(data_converter.ToString) then
+    label:SetText(data_converter.ToString(current_value));
+  else
+    label:SetText(current_value);
+  end
+
+  control:RegisterSliderCallback(
+    function()
+      local value = data_converter.ToValue(control:GetStep());
+      if(data_converter.ToString) then
+        label:SetText(data_converter.ToString(value));
+      else
+        label:SetText(value);
+      end
+
+      if(not control:IsTrackingLeftMouseButton() and hasScrolled == true) then
+        GameConfiguration.SetValue(setting_name, value);
+        LuaEvents.CQUI_SettingsUpdate();
+        hasScrolled = false;
+      else
+        hasScrolled = true;
+      end
+    end
+  );
+
+  if(tooltip ~= nil)then
+    control:SetToolTipString(tooltip);
+  end
+end
+
+-- Trims source information from gossip messages. Returns nil if the message couldn't be trimmed (this usually means the provided string wasn't a gossip message at all)
+function CQUI_TrimGossipMessage(str:string)
+  print_debug("ENTRY: CQUICommon - CQUI_TrimGossipMessage");
+  -- Get a sample of a gossip source string
+  local sourceSample = Locale.Lookup("LOC_GOSSIP_SOURCE_DELEGATE", "XX", "Y", "Z");
+
+  -- Get last word that occurs in the gossip source string. "that" in English.
+  -- Assumes the last word is always the same, which it is in English, unsure if this holds true in other languages
+  -- AZURENCY : the patterns means : any character 0 or +, XX exactly, any character 0 or +, space, any character other than space 1 or + at the end of the sentence.
+  -- AZURENCY : in some languages, there is no space, in that case, take the last character (often it's a ":")
+  last = string.match(sourceSample, ".-XX.-(%s%S+)$"); 
+  if last == nil then
+    last = string.match(sourceSample, ".-(.)$");
+  end
+
+  -- AZURENCY : if last is still nill, it's not normal, print an error but still allow the code to run
+  if last == nil then
+    print_debug("ERROR : LOC_GOSSIP_SOURCE_DELEGATE seems to be empty as last was still nil after the second pattern matching.")
+    last = ""
+  end
+
+ -- Return the rest of the string after the last word from the gossip source string
+  return Split(str, last .. " " , 2)[2];
+end
+
+
+function Initialize()
+  print_debug("INITIALZE: CQUICommon.lua");
+  LuaEvents.CQUI_SettingsUpdate.Add(CQUI_OnSettingsUpdate);
+  LuaEvents.CQUI_SettingsInitialized.Add(CQUI_OnSettingsUpdate);
+end
+Initialize();

--- a/Assets/UI/civ6common.lua
+++ b/Assets/UI/civ6common.lua
@@ -1,3 +1,6 @@
+--  CQUI: This is a copy of the Civ6Common.lua file found in the base game folder, this file will replace that one.
+--  CQUI: The ONLY change to this file from the base version (besides this comment) is the include("CQUICommon") declaration below
+
 ------------------------------------------------------------------------------
 --  Common LUA support functions specific to Civilization 6
 ------------------------------------------------------------------------------
@@ -5,7 +8,9 @@
 include( "ToolTipHelper" );
 include( "Colors" );
 include( "PortraitSupport" );
-
+--  CQUI: BEGIN CHANGE FROM UNMODIFIED BASE VERSION **************************************
+include( "CQUICommon" );
+--  CQUI: END CHANGE FROM UNMODIFIED BASE VERSION ****************************************
 
 -- ===========================================================================
 --  CONSTANTS
@@ -20,44 +25,33 @@ ProductionType = {
   UNIT    = "UNIT"
 }
 
--- ===========================================================================
---  VARIABLES
--- ===========================================================================
-
-local CQUI_ShowDebugPrint = false;
-
-function CQUI_OnSettingsUpdate()
-  CQUI_ShowDebugPrint = GameConfiguration.GetValue("CQUI_ShowDebugPrint") == 1
-end
-LuaEvents.CQUI_SettingsUpdate.Add(CQUI_OnSettingsUpdate);
-LuaEvents.CQUI_SettingsInitialized.Add(CQUI_OnSettingsUpdate);
-
 
 -- ===========================================================================
 --  FUNCTIONS
 -- ===========================================================================
 
+
 -- ===========================================================================
---	Return the height of the top panel
+--  Return the height of the top panel
 -- ===========================================================================
 function GetTopBarHeight() 
-  return 29;	-- Not height of context but where art/offset should start for content below it.
+  return 29; --   Not height of context but where art/offset should start for content below it.
 end
 
 -- ===========================================================================
 --  Return the inline text-icon for a given yield
---  yieldType A database YIELD_TYPE
+--  yieldType  A database YIELD_TYPE
 --  returns   The [ICON_yield] string
 -- ===========================================================================
 function GetYieldTextIcon( yieldType:string )
-  local  iconString:string = "";
-  if    yieldType == nil or yieldType == "" then
+  local iconString:string = "";
+  if yieldType == nil or yieldType == "" then
     iconString="Error:NIL";
-  elseif  GameInfo.Yields[yieldType] ~= nil and GameInfo.Yields[yieldType].IconString ~= nil and GameInfo.Yields[yieldType].IconString ~= "" then
+  elseif GameInfo.Yields[yieldType] ~= nil and GameInfo.Yields[yieldType].IconString ~= nil and GameInfo.Yields[yieldType].IconString ~= "" then
     iconString=GameInfo.Yields[yieldType].IconString;
   else
-    iconString = "Unknown:"..yieldType;
-  end
+    iconString = "Unknown:"..yieldType; 
+  end     
   return iconString;
 end
 
@@ -66,15 +60,15 @@ end
 --  Return the inline entry for a yield's color
 -- ===========================================================================
 function GetYieldTextColor( yieldType:string )
-  if    yieldType == nil or yieldType == "" then return "[COLOR:255,255,255,255]NIL ";
-  elseif  yieldType == "YIELD_FOOD"     then return "[COLOR:ResFoodLabelCS]";
-  elseif  yieldType == "YIELD_PRODUCTION"   then return "[COLOR:ResProductionLabelCS]";
-  elseif  yieldType == "YIELD_GOLD"     then return "[COLOR:ResGoldLabelCS]";
-  elseif  yieldType == "YIELD_SCIENCE"    then return "[COLOR:ResScienceLabelCS]";
-  elseif  yieldType == "YIELD_CULTURE"    then return "[COLOR:ResCultureLabelCS]";
-  elseif  yieldType == "YIELD_FAITH"      then return "[COLOR:ResFaithLabelCS]";
-  else                       return "[COLOR:255,255,255,0]ERROR ";
-  end
+  if yieldType == nil or yieldType == "" then return "[COLOR:255,255,255,255]NIL ";
+  elseif yieldType == "YIELD_FOOD"       then return "[COLOR:ResFoodLabelCS]";
+  elseif yieldType == "YIELD_PRODUCTION" then return "[COLOR:ResProductionLabelCS]";
+  elseif yieldType == "YIELD_GOLD"       then return "[COLOR:ResGoldLabelCS]";
+  elseif yieldType == "YIELD_SCIENCE"    then return "[COLOR:ResScienceLabelCS]";
+  elseif yieldType == "YIELD_CULTURE"    then return "[COLOR:ResCultureLabelCS]";
+  elseif yieldType == "YIELD_FAITH"      then return "[COLOR:ResFaithLabelCS]";
+  else                                        return "[COLOR:255,255,255,0]ERROR ";
+  end       
 end
 
 -- ===========================================================================
@@ -114,10 +108,10 @@ function MoveUnitToPlot( kUnit:table, plotX:number, plotY:number )
   if kUnit ~= nil then
     local tParameters:table = {};
     tParameters[UnitOperationTypes.PARAM_X] = plotX;
-    tParameters[UnitOperationTypes.PARAM_Y] = plotY;
-
-    -- Will this start a war?  Note, we are ignoring destinations in the for that will start a war, the unit will be allowed to move until they are adjacent.
-    -- We may want to also skip the war check if the move will take more than one turn to get to the destination.
+    tParameters[UnitOperationTypes.PARAM_Y] = plotY;    
+    
+    --   Will this start a war? Note, we are ignoring destinations in the for that will start a war, the unit will be allowed to move until they are adjacent.
+    --   We may want to also skip the war check if the move will take more than one turn to get to the destination.
     local eAttackingPlayer:number = kUnit:GetOwner();
     local eUnitComponentID:table = kUnit:GetComponentID();
     local bWillStartWar = false;
@@ -129,24 +123,24 @@ function MoveUnitToPlot( kUnit:table, plotX:number, plotY:number )
         bWillStartWar = true;
       end
     end
- 
+
     if (bWillStartWar) then
       local eDefendingPlayer = results[1];
-      -- Create the action specific parameters
+      --   Create the action specific parameters 
       if (eDefendingPlayer ~= nil and eDefendingPlayer ~= -1) then
         LuaEvents.Civ6Common_ConfirmWarDialog(eAttackingPlayer, eDefendingPlayer, WarTypes.SURPRISE_WAR);
       end
     else
       RequestMoveOperation(kUnit, tParameters, plotX, plotY);
     end
-  end
+  end     
 end
 
 -- ===========================================================================
 --  Requests an operation based on the type of unit and parameters
 -- ===========================================================================
 function RequestMoveOperation( kUnit:table, tParameters:table, plotX:number, plotY:number )
-  -- Air units move and attack slightly differently than land and naval units
+  --   Air units move and attack slightly differently than land and naval units
   if ( GameInfo.Units[kUnit:GetUnitType()].Domain == "DOMAIN_AIR" ) then
     tParameters[UnitOperationTypes.PARAM_MODIFIERS] = UnitOperationMoveModifiers.ATTACK;
     if (UnitManager.CanStartOperation( kUnit, UnitOperationTypes.AIR_ATTACK, nil, tParameters) ) then
@@ -159,14 +153,14 @@ function RequestMoveOperation( kUnit:table, tParameters:table, plotX:number, plo
     if (UnitManager.CanStartOperation( kUnit, UnitOperationTypes.RANGE_ATTACK, nil, tParameters) and (kUnit:GetRangedCombat() > kUnit:GetCombat() or kUnit:GetBombardCombat() > kUnit:GetCombat() ) ) then
       UnitManager.RequestOperation(kUnit, UnitOperationTypes.RANGE_ATTACK, tParameters);
     else
-      -- Allow for attacking and don't early out if the destination is blocked, etc., but is in the fog.
+      --   Allow for attacking and don't early out if the destination is blocked, etc., but is in the fog.
       tParameters[UnitOperationTypes.PARAM_MODIFIERS] = UnitOperationMoveModifiers.ATTACK + UnitOperationMoveModifiers.MOVE_IGNORE_UNEXPLORED_DESTINATION;
       if (UnitManager.CanStartOperation( kUnit, UnitOperationTypes.COASTAL_RAID, nil, tParameters) ) then
         UnitManager.RequestOperation( kUnit, UnitOperationTypes.COASTAL_RAID, tParameters);
       else
-        -- Check that unit isn't already in the plot (essentially canceling the move),
-        -- otherwise the operation will complete, and while no move is made, the next
-        -- unit will auto seltect.
+        --   Check that unit isn't already in the plot (essentially canceling the move),
+        --   otherwise the operation will complete, and while no move is made, the next
+        --   unit will auto seltect.
         if plotX ~= kUnit:GetX() or plotY ~= kUnit:GetY() then
           if (UnitManager.CanStartOperation( kUnit, UnitOperationTypes.SWAP_UNITS, nil, tParameters) ) then
             UnitManager.RequestOperation(kUnit, UnitOperationTypes.SWAP_UNITS, tParameters);
@@ -180,13 +174,61 @@ function RequestMoveOperation( kUnit:table, tParameters:table, plotX:number, plo
 end
 
 -- ===========================================================================
---  Multiplier value
+--  Multiplier value 
 --  Return a string with a colorized # and a +/- based on 1.0 based percent.
 -- ===========================================================================
 function GetColorPercentString( multiplier:number )
-  if    multiplier > 1 then return "[COLOR:StatGoodCS]+"..tostring((multiplier-1)*100).."%[ENDCOLOR]";
-  elseif  multiplier < 1 then return "[COLOR:StatBadCS]-"..tostring((1-multiplier)*100).."%[ENDCOLOR]";
+  if   multiplier > 1 then return "[COLOR:StatGoodCS]+"..tostring((multiplier-1)*100).."%[ENDCOLOR]";
+  elseif multiplier < 1 then return "[COLOR:StatBadCS]-"..tostring((1-multiplier)*100).."%[ENDCOLOR]";
   else          return "[COLOR:StatNormalCS]100%[ENDCOLOR]";
+  end
+end
+
+-- ===========================================================================
+--  Returns a Civ-specific format for date and time, given a total number
+--  of seconds (unmodulated), and whether or not the time is approximate
+-- ===========================================================================
+function FormatTimeRemaining( timeRemaining:number, bIsConcrete:boolean )
+  --   Format the time remaining string based on how much time we have left.
+  --   We manually floor our values using floor and % operations to prevent the localization system 
+  --   from rounding the values up.
+  local secs = timeRemaining % 60;
+  local mins = timeRemaining / 60;
+  local hours = timeRemaining / 3600;
+  local days = timeRemaining / 86400;
+  if(days >= 1) then
+    --   Days remaining
+    days = math.floor(days);
+    hours = hours % 24; --   cap hours
+    if(bIsConcrete) then
+      return Locale.Lookup("LOC_KEY_TIME_DAYS_HOURS", days, hours);
+    else
+      return Locale.Lookup("LOC_KEY_EST_TIME_DAYS_HOURS", days, hours);
+    end
+  elseif(hours >= 1) then
+    --   hours left
+    hours = math.floor(hours);
+    mins = mins % 60; --   cap mins
+    if(bIsConcrete) then
+      return Locale.Lookup("LOC_KEY_TIME_HOURS_MINUTES", hours, mins);
+    else
+      return Locale.Lookup("LOC_KEY_EST_TIME_HOURS_MINUTES", hours, mins);
+    end
+  elseif(mins >= 1) then
+    --   mins left
+    mins = math.floor(mins);
+    if(bIsConcrete) then
+      return Locale.Lookup("LOC_KEY_TIME_MINS_SECONDS", mins, secs);
+    else
+      return Locale.Lookup("LOC_KEY_EST_TIME_MINS_SECONDS", mins, secs);
+    end
+  else
+    --   secs left
+    if(bIsConcrete) then
+      return Locale.Lookup("LOC_KEY_TIME_SECONDS", secs);
+    else
+      return Locale.Lookup("LOC_KEY_EST_TIME_SECONDS", secs);
+    end
   end
 end
 
@@ -202,10 +244,10 @@ function GetUnitStats( hashOrType )
   end
   return {
     Bombard   = info.Bombard,
-    Combat    = info.Combat,
-    Moves   = info.BaseMoves,
+    Combat   = info.Combat,
+    Moves    = info.BaseMoves,
     RangedCombat= info.RangedCombat,
-    Range   = info.Range
+    Range    = info.Range
   }
 end
 
@@ -214,8 +256,8 @@ end
 --  RETURN 1: iconInfo - table containing textureSheet, textureOffsetX, and textureOffsetY
 --  RETURN 2: iconShadowInfo - table containing textureSheetShadow, textureOffsetShadowX, and textureOffsetShadowY
 -- ===========================================================================
-function GetUnitIcon( pUnit:table, iconSize:number )	
-
+function GetUnitIcon( pUnit:table, iconSize:number )  
+  
   local iconInfo:table = {};
   if pUnit then
 
@@ -227,20 +269,20 @@ function GetUnitIcon( pUnit:table, iconSize:number )
       local iconModifier:table = GameInfo.GreatPersonIndividualIconModifiers[individualType];
       if iconModifier then
         unitIcon = iconModifier.OverrideUnitIcon;
-      end
+      end 
     end
 
     if not unitIcon then
       local unit:table = GameInfo.Units[pUnit:GetUnitType()];
       unitIcon = "ICON_" .. unit.UnitType;
     end
-
+    
     iconInfo.textureOffsetX, iconInfo.textureOffsetY, iconInfo.textureSheet = IconManager:FindIconAtlas(unitIcon, iconSize);
-    if (iconInfo.textureSheet == nil) then      --Check to see if the unit has an icon atlas index defined
+    if (iconInfo.textureSheet == nil) then     --Check to see if the unit has an icon atlas index defined
       print("UIWARNING: Could not find icon for " .. unitIcon);
-      iconInfo.textureOffsetX, iconInfo.textureOffsetY, iconInfo.textureSheet = IconManager:FindIconAtlas("ICON_UNIT_UNKNOWN", iconSize);		--If not, resolve the index to be a generic unknown index
-      end
+      iconInfo.textureOffsetX, iconInfo.textureOffsetY, iconInfo.textureSheet = IconManager:FindIconAtlas("ICON_UNIT_UNKNOWN", iconSize);   --If not, resolve the index to be a generic unknown index
     end
+  end
   return iconInfo;
 end
 
@@ -259,7 +301,7 @@ function AutoSizeGridButton(gridButton:table,minX: number, minY: number, padding
   if (padding == nil) then
     padding = 0;
   end
-  local labelControl =  gridButton:GetTextControl();
+  local labelControl = gridButton:GetTextControl();
   local labelX = labelControl:GetSizeX() + padding*2;
   local labelY = labelControl:GetSizeY() + padding*2;
   if (minX ~= nil) then
@@ -280,56 +322,56 @@ end
 -- ===========================================================================
 function GetLeaderUniqueTraits( leaderType:string, useFullDescriptions:boolean )
 
-  -- Gather info.
-    local base_leader = GameInfo.Leaders[leaderType];
-    if(base_leader == nil) then
-        return;
-    end
+  --   Gather info.
+  local base_leader = GameInfo.Leaders[leaderType];
+  if(base_leader == nil) then
+    return;
+  end      
 
   function AddInheritedLeaders(leaders, leader)
     local inherit = leader.InheritFrom;
-        if(inherit ~= nil) then
-            local parent = GameInfo.Leaders[inherit];
-            if(parent) then
-                table.insert(leaders, parent);
-                AddInheritedLeaders(leaders, parent);
-            end
-        end
+    if(inherit ~= nil) then
+      local parent = GameInfo.Leaders[inherit];
+      if(parent) then
+        table.insert(leaders, parent);
+        AddInheritedLeaders(leaders, parent);
+      end
     end
+  end
 
   local leaders = {};
-    table.insert(leaders, base_leader);
+  table.insert(leaders, base_leader);
   AddInheritedLeaders(leaders, base_leader);
 
-  -- Enumerate final list and index.
+  --   Enumerate final list and index.
   local has_leader = {};
   for i,leader in ipairs(leaders) do
     has_leader[leader.LeaderType] = true;
   end
 
-  -- Unique Abilities
-  -- We're considering a unique ability to be a trait which does
-  -- not have a unique unit, building, district, or improvement associated with it.
-  -- While we scrub for unique units and infrastructure, mark traits that match
-  -- so we can filter them later.
-    local traits = {};
+  --   Unique Abilities
+  --   We're considering a unique ability to be a trait which does 
+  --   not have a unique unit, building, district, or improvement associated with it.
+  --   While we scrub for unique units and infrastructure, mark traits that match 
+  --   so we can filter them later.
+  local traits = {};
   local has_trait = {};
   local not_ability = {};
-    for row in GameInfo.LeaderTraits() do
-        if(has_leader[row.LeaderType] == true) then
+  for row in GameInfo.LeaderTraits() do
+    if(has_leader[row.LeaderType] == true) then
       local trait = GameInfo.Traits[row.TraitType];
       if(trait) then
-        table.insert(traits, trait);
+        table.insert(traits, trait);      
       end
       has_trait[row.TraitType] = true;
-        end
     end
+  end
 
-    -- Unique Units
-    local uu = {};
-    for row in GameInfo.Units() do
-        local trait = row.TraitType;
-        if(trait) then
+  --   Unique Units
+  local uu = {};
+  for row in GameInfo.Units() do
+    local trait = row.TraitType;
+    if(trait) then
       not_ability[trait] = true;
       if(has_trait[trait] == true) then
         local description :string = Locale.Lookup("LOC_LOADING_"..row.Domain);
@@ -338,56 +380,57 @@ function GetLeaderUniqueTraits( leaderType:string, useFullDescriptions:boolean )
         end
         table.insert(uu, { Type = row.UnitType, Name = row.Name, Description = description });
       end
-        end
     end
-
-    -- Unique Buildings/Districts/Improvements
-    local ub = {};
-    for row in GameInfo.Buildings() do
-        local trait = row.TraitType;
-        if(trait) then
+  end
+  
+  --   Unique Buildings/Districts/Improvements
+  local ub = {};
+  for row in GameInfo.Buildings() do
+    local trait = row.TraitType;
+    if(trait) then
       not_ability[trait] = true;
       if(has_trait[trait] == true) then
         local districtName:string = GameInfo.Districts[row.PrereqDistrict].Name;
         local description :string = Locale.Lookup("LOC_LOADING_UNIQUE_BUILDING");
         if m_isTraitsFullDescriptions or useFullDescriptions then
-          description = Locale.Lookup(GameInfo.Buildings[row.BuildingType].Description);
+          description = Locale.Lookup(GameInfo.Buildings[row.BuildingType].Description); 
         end
         table.insert(ub, {Type = row.BuildingType, Name = row.Name, Description = description});
       end
-        end
     end
+  end
 
-    for row in GameInfo.Districts() do
-        local trait = row.TraitType;
-        if(trait) then
+  for row in GameInfo.Districts() do
+    local trait = row.TraitType;
+    if(trait) then
       not_ability[trait] = true;
       if(has_trait[trait] == true) then
         local description :string = Locale.Lookup("LOC_LOADING_UNIQUE_DISTRICT");
         if m_isTraitsFullDescriptions or useFullDescriptions then
-          description = Locale.Lookup(GameInfo.Districts[row.DistrictType].Description);
+          description = Locale.Lookup(GameInfo.Districts[row.DistrictType].Description); 
         end
         table.insert(ub, {Type = row.DistrictType, Name = row.Name, Description = description});
       end
-        end
     end
+  end
 
-    for row in GameInfo.Improvements() do
-        local trait = row.TraitType;
-        if(trait) then
+  for row in GameInfo.Improvements() do
+    local trait = row.TraitType;
+    if(trait) then
       not_ability[trait] = true;
       if(has_trait[trait] == true) then
         local description :string = Locale.Lookup("LOC_LOADING_UNIQUE_IMPROVEMENT");
         if m_isTraitsFullDescriptions or useFullDescriptions then
-          description = Locale.Lookup(GameInfo.Improvements[row.ImprovementType].Description);
+          description = Locale.Lookup(GameInfo.Improvements[row.ImprovementType].Description); 
         end
         table.insert(ub, {Type = row.ImprovementType, Name = row.Name, Description = description});
       end
-        end
     end
+  end
 
   local unique_abilities = {};
   for i, trait in ipairs(traits) do
+    print(trait.InternalOnly);
     if(not_ability[trait.TraitType] ~= true and not trait.InternalOnly) then
       table.insert(unique_abilities, trait);
     end
@@ -399,26 +442,26 @@ end
 
 -- ===========================================================================
 function GetCivilizationUniqueTraits( civType:string, useFullDescriptions:boolean )
-
+  
   local traits = {};
-    for row in GameInfo.CivilizationTraits() do
-        if(row.CivilizationType == civType) then
-            traits[row.TraitType] = true;
-        end
+  for row in GameInfo.CivilizationTraits() do
+    if(row.CivilizationType == civType) then
+      traits[row.TraitType] = true;
     end
+  end
 
-  -- Unique Abilities
-  -- We're considering a unique ability to be a trait which does
-  -- not have a unique unit, building, district, or improvement associated with it.
-  -- While we scrub for unique units and infrastructure, mark traits that match
-  -- so we can filter them later.
+  --   Unique Abilities
+  --   We're considering a unique ability to be a trait which does 
+  --   not have a unique unit, building, district, or improvement associated with it.
+  --   While we scrub for unique units and infrastructure, mark traits that match 
+  --   so we can filter them later.
   local not_abilities = {};
-
-    -- Unique Units
-    local uu = {};
-    for row in GameInfo.Units() do
-        local trait = row.TraitType;
-        if(trait) then
+  
+  --   Unique Units
+  local uu = {};
+  for row in GameInfo.Units() do
+    local trait = row.TraitType;
+    if(trait) then
       not_abilities[trait] = true;
       if(traits[trait] == true) then
         local description :string = Locale.Lookup("LOC_LOADING_"..row.Domain);
@@ -427,59 +470,59 @@ function GetCivilizationUniqueTraits( civType:string, useFullDescriptions:boolea
         end
         table.insert(uu, { Type = row.UnitType, Name = row.Name, Description = description });
       end
-        end
     end
-
-    -- Unique Buildings/Districts/Improvements
-    local ub = {};
-    for row in GameInfo.Buildings() do
-        local trait = row.TraitType;
-        if(trait) then
+  end
+  
+  --   Unique Buildings/Districts/Improvements
+  local ub = {};
+  for row in GameInfo.Buildings() do
+    local trait = row.TraitType;
+    if(trait) then
       not_abilities[trait] = true;
       if(traits[trait] == true) then
-        local building    :table  = GameInfo.Buildings[row.BuildingType];
+        local building  :table = GameInfo.Buildings[row.BuildingType];
         local description :string = Locale.Lookup("LOC_LOADING_UNIQUE_BUILDING");
         if m_isTraitsFullDescriptions or useFullDescriptions then
           if building == nil then
             UI.DataError("Could not get CIV trait as GameInfo.Buildings["..row.BuildingType.."] does not exist.");
           elseif building.Description == nil then
-            UI.DataError("Could not get CIV trait description for GameInfo.Buildings["..row.BuildingType.."].  None supplied.");
+            UI.DataError("Could not get CIV trait description for GameInfo.Buildings["..row.BuildingType.."]. None supplied.");
           else
-            description = Locale.Lookup(building.Description);
-          end
+            description = Locale.Lookup(building.Description); 
+          end       
         end
         table.insert(ub, {Type = row.BuildingType, Name = row.Name, Description = description});
       end
-        end
     end
+  end
 
-    for row in GameInfo.Districts() do
-        local trait = row.TraitType;
-        if(trait) then
+  for row in GameInfo.Districts() do
+    local trait = row.TraitType;
+    if(trait) then
       not_abilities[trait] = true;
       if(traits[trait] == true) then
         local description :string = Locale.Lookup("LOC_LOADING_UNIQUE_DISTRICT");
         if m_isTraitsFullDescriptions or useFullDescriptions then
-          description = Locale.Lookup(GameInfo.Districts[row.DistrictType].Description);
+          description = Locale.Lookup(GameInfo.Districts[row.DistrictType].Description); 
         end
         table.insert(ub, {Type = row.DistrictType, Name = row.Name, Description = description});
       end
-        end
     end
+  end
 
-    for row in GameInfo.Improvements() do
-        local trait = row.TraitType;
-        if(trait) then
+  for row in GameInfo.Improvements() do
+    local trait = row.TraitType;
+    if(trait) then
       not_abilities[trait] = true;
       if(traits[trait] == true) then
         local description :string = Locale.Lookup("LOC_LOADING_UNIQUE_IMPROVEMENT");
         if m_isTraitsFullDescriptions or useFullDescriptions then
-          description = Locale.Lookup(GameInfo.Improvements[row.ImprovementType].Description);
+          description = Locale.Lookup(GameInfo.Improvements[row.ImprovementType].Description); 
         end
         table.insert(ub, {Type = row.ImprovementType, Name = row.Name, Description = description});
       end
-        end
     end
+  end
 
   local unique_abilities = {};
   for row in GameInfo.CivilizationTraits() do
@@ -487,47 +530,47 @@ function GetCivilizationUniqueTraits( civType:string, useFullDescriptions:boolea
       local trait = GameInfo.Traits[row.TraitType];
       if(trait) then
         table.insert(unique_abilities, trait);
-      end
+      end     
     end
   end
 
   return unique_abilities, uu, ub;
 end
-
+  
 
 -- ===========================================================================
 --  Is the on-rails tutorial active?
 -- ===========================================================================
 function IsTutorialRunning()
-  return Modding.IsModActive(TUTORIAL_UUID); 
+  return Modding.IsModActive(TUTORIAL_UUID);
 end
 
 -- ===========================================================================
 --  DifferentiateCiv
--- ===========================================================================
---  This is a fix for duplicate civs.  If you feed it a control, it will generate a tooltip which lists the cities for that civ, to help differentiate which civ you are currently viewing.
---  Note: This function does NOT contain the IsDuplicate? check.  Use this function once you have already determined whether or not you wish to differentiate the civ.
+-- =========================================================================== 
+--  This is a fix for duplicate civs. If you feed it a control, it will generate a tooltip which lists the cities for that civ, to help differentiate which civ you are currently viewing.
+--  Note: This function does NOT contain the IsDuplicate? check. Use this function once you have already determined whether or not you wish to differentiate the civ.
 --  Additionally, you can pass icon backing/icon controls to be colored with the civ's colors.
---  ARG1 playerID (number)            The player id of the civ in question
+--  ARG1 playerID  (number)            The player id of the civ in question
 --  ARG2 tooltipControl (table)     OPTIONAL  This is the control that should receive the tooltip
---  ARG3 icon (table)         OPTIONAL  The icon control which will receive the foreground color for the civ
+--  ARG3 icon (table)          OPTIONAL  The icon control which will receive the foreground color for the civ
 --  ARG4 iconBacking (table)      OPTIONAL  The image behind the icon which will receive the background color for the civ
---  ARG5 iconBackingDarker (table)    OPTIONAL  If you are making a fancy icon with more depth, you can additionally pass the layer to be darkened
+--  ARG5 iconBackingDarker (table)   OPTIONAL  If you are making a fancy icon with more depth, you can additionally pass the layer to be darkened
 --  ARG6 iconBackingLighter (table)   OPTIONAL  .. and also the layer to be lightened
---  ARG7 observerPlayerID (number)    OPTIONAL  Checks if the players met
+--  ARG7 observerPlayerID (number)   OPTIONAL  Checks if the players met 
 --  RETURNS (string)                String to be used as a tooltip which lists Civ name, Leader/Player name, list of cities
 function DifferentiateCiv(playerID:number, tooltipControl:table, icon:table, iconBacking:table, iconBackingDarker:table, iconBackingLighter:table, observerPlayerID:number)
-
+  
   local player:table = Players[playerID];
   local playerConfig:table = PlayerConfigurations[playerID];
-
+  
   local hasMet:boolean = true;
   if player ~= nil and observerPlayerID ~= nil and playerID ~= observerPlayerID then
     hasMet = player:GetDiplomacy():HasMet(observerPlayerID);
   end
 
   if (player ~= nil and hasMet and iconBacking ~= nil and icon ~= nil) then
-    m_primaryColor, m_secondaryColor  = UI.GetPlayerColors( playerID );
+    m_primaryColor, m_secondaryColor = UI.GetPlayerColors( playerID );
     iconBacking:SetColor(m_primaryColor);
     if(iconBackingLighter ~= nil and iconBackingDarker ~= nil) then
       local darkerBackColor = UI.DarkenLightenColor(m_primaryColor,(-85),100);
@@ -538,7 +581,7 @@ function DifferentiateCiv(playerID:number, tooltipControl:table, icon:table, ico
     icon:SetColor(m_secondaryColor);
   end
 
-  -- Set the leader name, civ name, and civ icon data
+  --   Set the leader name, civ name, and civ icon data
   local civTypeName = playerConfig:GetCivilizationTypeName();
   if civTypeName ~= nil then
     local civIcon:string;
@@ -575,14 +618,14 @@ function DifferentiateCiv(playerID:number, tooltipControl:table, icon:table, ico
         civTooltip = civTooltip .. " ("..Locale.Lookup(playerName)..")";
       end
     end
-
+      
     if (icon ~= nil) then
       icon:SetIcon(civIcon);
     end
     if (tooltipControl ~= nil) then
       tooltipControl:SetToolTipString(Locale.Lookup(civTooltip));
     end
-    return civTooltip;
+    return civTooltip
   else
     UI.DataError("Invalid type name returned by GetCivilizationTypeName");
   end
@@ -602,7 +645,7 @@ function GetGreatWorksForCity( pCity:table )
         if (numSlots ~= nil and numSlots > 0) then
           local greatWorksInBuilding:table = {};
 
-          -- populate great works
+          --   populate great works
           for index:number=0, numSlots - 1 do
             local greatWorkIndex:number = pCityBldgs:GetGreatWorkInSlot(buildingIndex, index);
             if greatWorkIndex ~= -1 then
@@ -611,7 +654,7 @@ function GetGreatWorksForCity( pCity:table )
             end
           end
 
-          -- create association between building type and great works
+          --   create association between building type and great works
           if table.count(greatWorksInBuilding) > 0 then
             result[buildingType] = greatWorksInBuilding;
           end
@@ -623,7 +666,7 @@ function GetGreatWorksForCity( pCity:table )
 end
 
 -- ===========================================================================
---	Is a diplomacy for the local player.
+--  Is a diplomacy for the local player.
 -- ===========================================================================
 function IsDiplomacyPending()
   local localPlayerId:number = Game.GetLocalPlayer();
@@ -637,7 +680,7 @@ function IsDiplomacyPending()
 end
 
 -- ===========================================================================
---	Is diplomacy open for thelocal player.
+--  Is diplomacy open for thelocal player.
 -- ===========================================================================
 function IsDiplomacyOpen()
   local localPlayerId:number = Game.GetLocalPlayer();
@@ -648,7 +691,7 @@ function IsDiplomacyOpen()
   local localPlayer :table = Players[localPlayerId];
   local pOtherPlayer:table = nil;
   
-  -- Loop through all the players whom could have 
+  --   Loop through all the players whom could have 
   for iPlayer = 0,63,1 do
     local pPlayerConfig = PlayerConfigurations[iPlayer];
 
@@ -664,12 +707,12 @@ function IsDiplomacyOpen()
 end
 
 -- ===========================================================================
---	RETURNS: true if a player does not have any cities.
+--  RETURNS: true if a player does not have any cities.
 -- ===========================================================================
 function IsPlayerCityless( playerID:number )
   if playerID < 0 then return true; end
-  local pPlayer		:table = Players[playerID];
-  local pPlayerCities	:table = pPlayer:GetCities();
+  local pPlayer    :table = Players[playerID];
+  local pPlayerCities :table = pPlayer:GetCities();
   for i, pCity in pPlayerCities:Members() do
     return false;
   end
@@ -677,9 +720,9 @@ function IsPlayerCityless( playerID:number )
 end
 
 -- ===========================================================================
---	Serialize custom data in the custom data table.
---	key		must be a string
---	value	can be anything
+--  Serialize custom data in the custom data table.
+--  key   must be a string
+--  value  can be anything
 -- ===========================================================================
 function WriteCustomData( key:string, value )
   local pParameters :table = UI.GetGameParameters():Add("CustomData");
@@ -693,16 +736,16 @@ function WriteCustomData( key:string, value )
 end
 
 -- ===========================================================================
---	Read back custom data, returns NIL if not found.
---	key		must be a string
---	RETURNS: all values from the associated key (or nil if key isn't found)
+--  Read back custom data, returns NIL if not found.
+--  key   must be a string
+--  RETURNS: all values from the associated key (or nil if key isn't found)
 -- ===========================================================================
 function ReadCustomData( key:string )
-  local pParameters	:table = UI.GetGameParameters():Get("CustomData");
-  local kReturn		:table = {};
+  local pParameters  :table = UI.GetGameParameters():Get("CustomData");
+  local kReturn    :table = {};
   if pParameters ~= nil then
-    local pValues:table = pParameters:Get( key );		
-    -- No key or empty key?  Return nil...
+    local pValues:table = pParameters:Get( key );    
+    --   No key or empty key? Return nil...
     if pValues == nil then
       return nil;
     end
@@ -720,172 +763,18 @@ function ReadCustomData( key:string )
   return unpack(kReturn);
 end
 
---CQUI setting control support functions
-
---Used to register a control to be updated whenever settings update (only necessary for controls that can be updated from multiple places)
-function RegisterControl(control, setting_name, update_function, extra_data)
-  LuaEvents.CQUI_SettingsUpdate.Add(function() update_function(control, setting_name, extra_data); end);
-end
-
---Companion functions to RegisterControl
-function UpdateComboBox(control, setting_name, values)
-  --This is a tough one! TODO for later
-end
-
-function UpdateCheckbox(control, setting_name)
-  local value = GameConfiguration.GetValue(setting_name);
-  if(value == nil) then return; end
-  control:SetSelected(value);
-end
-
-function UpdateSlider( control, setting_name, data_converter)
-  local value = GameConfiguration.GetValue(setting_name);
-  if(value == nil) then return; end
-  control:SetStep(data_converter.ToSteps(value));
-end
-
---Used to populate combobox options
-function PopulateComboBox(control, values, setting_name, tooltip)
-  control:ClearEntries();
-  local current_value = GameConfiguration.GetValue(setting_name);
-  if(current_value == nil) then
-  if(GameInfo.CQUI_Settings[setting_name]) then --LY Checks if this setting has a default state defined in the database
-    current_value = GameInfo.CQUI_Settings[setting_name].Value; --reads the default value from the database. Set them in Settings.sql
-  else current_value = 0;
-  end
-    GameConfiguration.SetValue(setting_name, current_value); --/LY
-  end
-  for i, v in ipairs(values) do
-    local instance = {};
-    control:BuildEntry( "InstanceOne", instance );
-    instance.Button:SetVoid1(i);
-        instance.Button:LocalizeAndSetText(v[1]);
-    if(v[2] == current_value) then
-      local button = control:GetButton();
-      button:LocalizeAndSetText(v[1]);
-    end
-  end
-  control:CalculateInternals();
-  if(setting_name) then
-    control:RegisterSelectionCallback(
-      function(voidValue1, voidValue2, control)
-        local option = values[voidValue1];
-        local button = control:GetButton();
-        button:LocalizeAndSetText(option[1]);
-        GameConfiguration.SetValue(setting_name, option[2]);
-        LuaEvents.CQUI_SettingsUpdate();
-      end
-    );
-  end
-  if(tooltip ~= nil)then
-    control:SetToolTipString(tooltip);
-  end
-end
-
---Used to populate checkboxes
-function PopulateCheckBox(control, setting_name, tooltip)
-  local current_value = GameConfiguration.GetValue(setting_name);
-  if(current_value == nil) then
-    if(GameInfo.CQUI_Settings[setting_name]) then --LY Checks if this setting has a default state defined in the database
-      if(GameInfo.CQUI_Settings[setting_name].Value == 0) then --because 0 is true in Lua
-        current_value = false;
-      else
-        current_value = true;
-      end
-    else current_value = false;
-    end
-    GameConfiguration.SetValue(setting_name, current_value); --/LY
-  end
-  if(current_value == false) then
-    control:SetSelected(false);
-  else
-    control:SetSelected(true);
-  end
-  control:RegisterCallback(Mouse.eLClick,
-    function()
-      local selected = not control:IsSelected();
-      control:SetSelected(selected);
-      GameConfiguration.SetValue(setting_name, selected);
-      LuaEvents.CQUI_SettingsUpdate();
-    end
-  );
-  if(tooltip ~= nil)then
-    control:SetToolTipString(tooltip);
-  end
-end
-
---Used to populate sliders. data_converter is a table containing two functions: ToStep and ToValue, which describe how to hanlde converting from the incremental slider steps to a setting value, think of it as a less elegant inner class
---Optional third function: ToString. When included, this function will handle how the value is converted to a display value, otherwise this defaults to using the value from ToValue
-function PopulateSlider(control, label, setting_name, data_converter, tooltip)
-  local hasScrolled = false; --Necessary because RegisterSliderCallback fires twice when releasing the mouse cursor for some reason
-  local current_value = GameConfiguration.GetValue(setting_name);
-  if(current_value == nil) then
-    if(GameInfo.CQUI_Settings[setting_name]) then --LY Checks if this setting has a default state defined in the database
-      current_value = GameInfo.CQUI_Settings[setting_name].Value;
-    else current_value = 0; end
-    GameConfiguration.SetValue(setting_name, current_value); --/LY
-  end
-  control:SetStep(data_converter.ToSteps(current_value));
-  if(data_converter.ToString) then
-    label:SetText(data_converter.ToString(current_value));
-  else
-    label:SetText(current_value);
-  end
-  control:RegisterSliderCallback(
-    function()
-      local value = data_converter.ToValue(control:GetStep());
-      if(data_converter.ToString) then
-        label:SetText(data_converter.ToString(value));
-      else
-        label:SetText(value);
-      end
-      if(not control:IsTrackingLeftMouseButton() and hasScrolled == true) then
-        GameConfiguration.SetValue(setting_name, value);
-        LuaEvents.CQUI_SettingsUpdate();
-        hasScrolled = false;
-      else hasScrolled = true; end
-    end
-  );
-  if(tooltip ~= nil)then
-    control:SetToolTipString(tooltip);
-  end
-end
-
---Trims source information from gossip messages. Returns nil if the message couldn't be trimmed (this usually means the provided string wasn't a gossip message at all)
-function CQUI_TrimGossipMessage(str:string)
-  local sourceSample = Locale.Lookup("LOC_GOSSIP_SOURCE_DELEGATE", "XX", "Y", "Z"); --Get a sample of a gossip source string
-  last = string.match(sourceSample, ".-XX.-(%s%S+)$"); --Get last word that occurs in the gossip source string. "that" in English. Assumes the last word is always the same, which it is in English, unsure if this holds true in other languages
-  -- AZURENCY : the patterns means : any character 0 or +, XX exactly, any character 0 or +, space, any character other than space 1 or + at the end of the sentence.
-  -- AZURENCY : in some languages, there is no space, in that case, take the last character (often it's a ":")
-  if last == nil then
-    last = string.match(sourceSample, ".-(.)$");
-  end
-  -- AZURENCY : if last is still nill, it's not normal, print an error but still allow the code to run
-  if last == nil then
-    print("ERROR : LOC_GOSSIP_SOURCE_DELEGATE seems to be empty as last was still nil after the second pattern matching.")
-    last = ""
-  end
-  return Split(str, last .. " " , 2)[2]; --Get the rest of the string after the last word from the gossip source string
-end
-
-function print_debug(str)
-  if CQUI_ShowDebugPrint then
-    print(str)
-  end
-end
-
 -- ===========================================================================
---	If the official Civ6 Expansion "Rise and Fall" (XP1) is active.
+--  If the official Civ6 Expansion "Rise and Fall" (XP1) is active.
 -- ===========================================================================
 function IsExpansion1Active()
-  local isActive:boolean  = Modding.IsModActive("1B28771A-C749-434B-9053-D1380C553DE9");
+  local isActive:boolean = Modding.IsModActive("1B28771A-C749-434B-9053-D1380C553DE9");
   return isActive;
 end
 
 -- ===========================================================================
---	If the official Civ6 Expansion "Gathering Storm" (XP2) is active.
+--  If the official Civ6 Expansion "Gathering Storm" (XP2) is active.
 -- ===========================================================================
 function IsExpansion2Active()
-  local isActive:boolean  = Modding.IsModActive("4873eb62-8ccc-4574-b784-dda455e74e68");
+  local isActive:boolean = Modding.IsModActive("4873eb62-8ccc-4574-b784-dda455e74e68");
   return isActive;
 end

--- a/Assets/cqui_main.lua
+++ b/Assets/cqui_main.lua
@@ -1,7 +1,7 @@
---This is the main CQUI script. There's not much here yet!
+-- This is the main CQUI script. There's not much here yet!
+-- TODO: Is this file required?  The inclusion of such file isn't seen in many other mods.
 
 function Initialize()
-  print("CQUI Loaded! Update for v1.0.0.314 (2019-05-12)");
+  print("CQUI Loaded! Update for v1.0.1.501 (2020-05-22)");
 end
-
 Initialize();

--- a/Assets/cqui_settings.sql
+++ b/Assets/cqui_settings.sql
@@ -14,9 +14,6 @@
     ║ copy of this file named "cqui_settings_local.sql" and make your changes there.             ║
     ║ The "cqui_settings_local.sql" file does not need to be a perfect copy and will work as     ║
     ║ long as it's valid SQL.                                                                    ║
-    ║                                                                                            ║
-    ║ If you discover a broken setting, please report it at the below URL:                       ║
-    ║                     https://github.com/CQUI-Org/cqui/issues                                ║
     ╚════════════════════════════════════════════════════════════════════════════════════════════╝
 */
 
@@ -42,7 +39,7 @@ INSERT OR REPLACE INTO CQUI_Settings -- Don't touch this line!
       ("CQUI_ProductionQueue", 1), -- A production queue appears next to the production panel, allowing multiple constructions to be queued at once
       ("CQUI_ShowCultureGrowth", 1), -- Shows cultural growth overlay in cityview
       ("CQUI_ShowPolicyReminder", 1),
-	  ("CQUI_ShowLuxuries", 1), -- Luxury resources will show in the top-bar next to strategic resources
+	    ("CQUI_ShowLuxuries", 1), -- Luxury resources will show in the top-bar next to strategic resources
       ("CQUI_ShowUnitPaths", 1), -- Shows unit paths on hover and selection
       ("CQUI_ShowYieldsOnCityHover", 1), -- Shows city management info like citizens, tile yields, and tile growth on hover
       ("CQUI_Smartbanner", 1), -- Additional informations such as districts will show in the city banner

--- a/CQUI.modinfo
+++ b/CQUI.modinfo
@@ -3,9 +3,9 @@
   <!-- ==============================  Basic Mod Information ============================== -->
   <Properties>
     <AffectsSavedGames>1</AffectsSavedGames>
-    <Name>Community Quick User Interface (Local Copy)</Name>
+    <Name>Community Quick User Interface</Name>
     <Teaser>CQUI</Teaser>
-    <Description>(Local Copy) Community Quick User Interface MOD was Formally CQUI Mod [NEWLINE]and is now being updated and improved by its community</Description>
+    <Description>Community Quick User Interface MOD was Formally CQUI Mod [NEWLINE]and is now being updated and improved by its community</Description>
     <CompatibleVersions>2.0</CompatibleVersions>
   </Properties>
 

--- a/CQUI.modinfo
+++ b/CQUI.modinfo
@@ -1,16 +1,15 @@
 <?xml version="1.0" encoding="utf-8"?>
-<Mod id="1d44b5e7-753e-405b-af24-5ee634ec8a01" version="1">
-
-  <!-- Basic Mod Information -->
+<Mod id="1d44b5e7-753e-405b-af24-5ee634ec8a01" version="4.0">
+  <!-- ==============================  Basic Mod Information ============================== -->
   <Properties>
     <AffectsSavedGames>1</AffectsSavedGames>
-    <Name>Community Quick User Interface</Name>
+    <Name>Community Quick User Interface (Local Copy)</Name>
     <Teaser>CQUI</Teaser>
-    <Description>Community Quick User Interface MOD was Formally CQUI Mod [NEWLINE]and is now being updated and improved by its community</Description>
+    <Description>(Local Copy) Community Quick User Interface MOD was Formally CQUI Mod [NEWLINE]and is now being updated and improved by its community</Description>
     <CompatibleVersions>2.0</CompatibleVersions>
   </Properties>
 
-  <!--Incompatible mods.-->
+  <!--============================== Incompatible mods ============================== -->
   <Blocks>
     <Mod id="9e9923e5-6842-4e7d-97e7-c9a56a85cf03" title="Simplified Gossip" />
     <Mod id="37b5fdca-2690-96ff-ea23-d8612ae7a757" title="Divine Yuri's Custom City Panel" />
@@ -21,7 +20,7 @@
     <Mod id="c9d28cde-61ee-459c-93f5-c734cd392553" title="NQ Enhanced User Interface" />
   </Blocks>
 
-  <!-- Modinfo Specific LOC -->
+  <!-- ==============================  Modinfo Specific LOC ============================== -->
   <LocalizedText>
     <Text id="CQUI_TEASER">
       <en_US>Reduce clicks and make empire management easy.</en_US>
@@ -36,249 +35,7 @@
     </Text>
   </LocalizedText>
 
-  <!-- Complete File Manifest -->
-  <Files>
-    <File>CQUI.dep</File>
-    <File>Assets/cqui_databaseschema.sql</File>
-    <File>Assets/cqui_settings.sql</File>
-    <File>Assets/cqui_settings_local.sql</File>
-    <File>Assets/cqui_settingselement.lua</File>
-    <File>Assets/cqui_settingselement.xml</File>
-    <File>Assets/cqui_main.lua</File>
-    <File>Assets/cqui_toplayer.xml</File>
-    <File>Assets/cqui_toplayer.lua</File>
-
-    <!-- EXP 1 -->
-    <File>Assets/Expansion1/CityBanners/citybannermanager.lua</File>
-    <File>Assets/Expansion1/CityBanners/citybannermanager.xml</File>
-    <File>Assets/Expansion1/CityBanners/citybannerinstances.xml</File>
-    <File>Assets/Expansion1/Replacements/citypanelculture_CQUI.lua</File>
-    <File>Assets/Expansion1/Replacements/citypaneloverview_expansion1_CQUI.lua</File>
-    <File>Assets/Expansion1/Replacements/citystates.xml</File>
-    <File>Assets/Expansion1/Replacements/citysupport.lua</File>
-    <File>Assets/Expansion1/Replacements/diplomacyactionview_CQUI_expansion1.lua</File>
-    <File>Assets/Expansion1/Replacements/governmentscreen_CQUI_expansion1.lua</File>
-    <File>Assets/Expansion1/Replacements/leadericon.lua</File>
-    <File>Assets/Expansion1/Replacements/leadericon.xml</File>
-    <File>Assets/Expansion1/Replacements/notificationpanel_CQUI_expansion1.lua</File>
-    <File>Assets/Expansion1/Replacements/partialscreenhooks_CQUI_expansion1.lua</File>
-    <File>Assets/Expansion1/Replacements/techtree_CQUI_expansion1.lua</File>
-    <File>Assets/Expansion1/Replacements/toppanel_CQUI_expansion1.lua</File>
-    <File>Assets/Expansion1/Replacements/unitpanel_CQUI_expansion1.lua</File>
-    <File>Assets/Expansion1/Replacements/worldtracker_expansion1.lua</File>
-
-    <!-- EXP 2 -->
-    <File>Assets/Expansion2/Replacements/citypaneloverview_expansion2_CQUI.lua</File>
-    <File>Assets/Expansion2/Replacements/citystates.xml</File>
-    <File>Assets/Expansion2/Replacements/citysupport.lua</File>
-    <File>Assets/Expansion2/Replacements/civicstree_CQUI_expansion2.lua</File>
-    <File>Assets/Expansion2/Replacements/diplomacyactionview_CQUI_expansion2.lua</File>
-    <File>Assets/Expansion2/Replacements/diplomacyactionview.xml</File>
-    <File>Assets/Expansion2/Replacements/diplomacydealview_CQUI_expansion2.lua</File>
-    <File>Assets/Expansion2/Replacements/diplomacyribbon.xml</File>
-    <File>Assets/Expansion2/Replacements/governmentscreen_CQUI_expansion2.lua</File>
-    <File>Assets/Expansion2/Replacements/ingame.lua</File>
-    <File>Assets/Expansion2/Replacements/notificationpanel_CQUI_expansion2.lua</File>
-    <File>Assets/Expansion2/Replacements/partialscreenhooks_CQUI_expansion2.lua</File>
-    <File>Assets/Expansion2/Replacements/plottooltip_CQUI_expansion2.lua</File>
-    <File>Assets/Expansion2/Replacements/techtree_CQUI_expansion2.lua</File>
-    <File>Assets/Expansion2/Replacements/toppanel_CQUI_expansion2.lua</File>
-    <File>Assets/Expansion2/Replacements/unitpanel_CQUI_expansion2.lua</File>
-    <File>Assets/Expansion2/CityBanners/citybannermanager.lua</File>
-    <File>Assets/Expansion2/CityBanners/citybannerinstances.xml</File>
-
-    <File>Integrations/URS/Expansion1/Replacements/reportscreen_expansion1.lua</File>
-    <File>Integrations/URS/Expansion1/Replacements/reportscreen.xml</File>
-    <File>Assets/Text/Gossip_Text.xml</File>
-    <File>Assets/Text/Gossip_Text_de.xml</File>
-    <File>Assets/Text/Gossip_Text_ja.xml</File>
-    <File>Assets/Text/Gossip_Text_pt.xml</File>
-    <File>Assets/Text/Gossip_Text_it.xml</File>
-    <File>Assets/Text/cqui_InGameText.xml</File>
-    <File>Assets/Text/cqui_InGameText_de.xml</File>
-    <File>Assets/Text/cqui_InGameText_ja.xml</File>
-    <File>Assets/Text/cqui_InGameText_it.xml</File>
-    <File>Assets/Text/cqui_text_general.xml</File>
-    <File>Assets/Text/cqui_text_general_de.xml</File>
-    <File>Assets/Text/cqui_text_general_es.xml</File>
-    <File>Assets/Text/cqui_text_general_fr.xml</File>
-    <File>Assets/Text/cqui_text_general_it.xml</File>
-    <File>Assets/Text/cqui_text_general_ja.xml</File>
-    <File>Assets/Text/cqui_text_general_ko.xml</File>
-    <File>Assets/Text/cqui_text_general_pl.xml</File>
-    <File>Assets/Text/cqui_text_general_pt.xml</File>
-    <File>Assets/Text/cqui_text_general_ru.xml</File>
-    <File>Assets/Text/cqui_text_general_zh.xml</File>
-    <File>Assets/Text/cqui_text_settings.xml</File>
-    <File>Assets/Text/cqui_text_settings_de.xml</File>
-    <File>Assets/Text/cqui_text_settings_es.xml</File>
-    <File>Assets/Text/cqui_text_settings_fr.xml</File>
-    <File>Assets/Text/cqui_text_settings_it.xml</File>
-    <File>Assets/Text/cqui_text_settings_ja.xml</File>
-    <File>Assets/Text/cqui_text_settings_ko.xml</File>
-    <File>Assets/Text/cqui_text_settings_pl.xml</File>
-    <File>Assets/Text/cqui_text_settings_pt.xml</File>
-    <File>Assets/Text/cqui_text_settings_ru.xml</File>
-    <File>Assets/Text/cqui_text_settings_zh.xml</File>
-    <File>Assets/Texture/CQUI_GreatPeople_Background_Bottom.dds</File>
-    <File>Assets/Texture/CQUI_GreatPeople_Background_Repeat_Bottom.dds</File>
-    <File>Assets/Texture/CQUI_GreatPeople_Background_Repeat_Top.dds</File>
-    <File>Assets/Texture/CQUI_GreatPeople_Background_Top.dds</File>
-    <File>Assets/UI/actionpanel.lua</File>
-    <File>Assets/UI/citysupport.lua</File>
-    <File>Assets/UI/civ6common.lua</File>
-    <File>Assets/UI/diplomacyactionview_CQUI_basegame.lua</File>
-    <File>Assets/UI/diplomacyactionview_CQUI.lua</File>
-    <File>Assets/UI/diplomacyactionview.xml</File>
-    <File>Assets/UI/diplomacydealview_CQUI_basegame.lua</File>
-    <File>Assets/UI/diplomacydealview_CQUI.lua</File>
-    <File>Assets/UI/diplomacydealview.xml</File>
-    <File>Assets/UI/diplomacyribbon.lua</File>
-    <File>Assets/UI/diplomacyribbon.xml</File>
-    <File>Assets/UI/ingame.lua</File>
-    <File>Assets/UI/launchbar.lua</File>
-    <File>Assets/UI/launchbar.xml</File>
-    <File>Assets/UI/leadericon.lua</File>
-    <File>Assets/UI/partialscreenhooks_CQUI_basegame.lua</File>
-    <File>Assets/UI/partialscreenhooks_CQUI.lua</File>
-    <File>Assets/UI/partialscreenhooks.xml</File>
-    <File>Assets/UI/productionpanel.xml</File>
-    <File>Assets/UI/supportfunctions.lua</File>
-    <File>Assets/UI/techandcivicsupport.lua</File>
-    <File>Assets/UI/toppanel_CQUI_basegame.lua</File>
-    <File>Assets/UI/toppanel_CQUI.lua</File>
-    <File>Assets/UI/unitflagmanager_CQUI.lua</File>
-    <File>Assets/UI/unitflagmanager.xml</File>
-    <File>Assets/UI/worldinput.lua</File>
-    <File>Assets/UI/worldtracker.lua</File>
-    <File>Assets/UI/worldtracker.xml</File>
-    <File>Assets/UI/worldviewiconsmanager_CQUI.lua</File>
-    <File>Assets/UI/Choosers/civicschooser.lua</File>
-    <File>Assets/UI/Choosers/researchchooser.lua</File>
-    <File>Assets/UI/Panels/citypanel.lua</File>
-    <File>Assets/UI/Panels/citypanel.xml</File>
-    <File>Assets/UI/Panels/citypaneloverview.lua</File>
-    <File>Assets/UI/Panels/citypaneloverview.xml</File>
-    <File>Assets/UI/Panels/notificationpanel_CQUI_basegame.lua</File>
-    <File>Assets/UI/Panels/notificationpanel_CQUI.lua</File>
-    <File>Assets/UI/Panels/productionpanel_CQUI.lua</File>
-    <File>Assets/UI/Panels/statusmessagepanel.lua</File>
-    <File>Assets/UI/Panels/statusmessagepanel.xml</File>
-    <File>Assets/UI/Panels/unitpanel_CQUI_basegame.lua</File>
-    <File>Assets/UI/Panels/unitpanel_CQUI.lua</File>
-    <File>Assets/UI/PartialScreens/citystates.lua</File>
-    <File>Assets/UI/PartialScreens/citystates.xml</File>
-    <File>Assets/UI/Popups/greatpeoplepopup.lua</File>
-    <File>Assets/UI/Popups/greatpeoplepopup.xml</File>
-    <File>Assets/UI/Popups/policyreminderpopup.lua</File>
-    <File>Assets/UI/Popups/policyreminderpopup.xml</File>
-    <File>Assets/UI/Popups/techciviccompletedpopup.lua</File>
-    <File>Assets/UI/Popups/wonderbuiltpopup_CQUI.lua</File>
-    <File>Assets/UI/Screens/civicstree_CQUI_basegame.lua</File>
-    <File>Assets/UI/Screens/civicstree_CQUI.lua</File>
-    <File>Assets/UI/Screens/governmentscreen_CQUI_basegame.lua</File>
-    <File>Assets/UI/Screens/governmentscreen_CQUI.lua</File>
-    <File>Assets/UI/Screens/techtree_CQUI_basegame.lua</File>
-    <File>Assets/UI/Screens/techtree_CQUI.lua</File>
-    <File>Assets/UI/ToolTips/plottooltip_CQUI_basegame.lua</File>
-    <File>Assets/UI/ToolTips/plottooltip_CQUI.lua</File>
-    <File>Assets/UI/Utilities/extendedrelationship.lua</File>
-    <File>Assets/UI/WorldView/citybannermanager.lua</File>
-    <File>Assets/UI/WorldView/citybannermanager.xml</File>
-    <File>Assets/UI/WorldView/districtploticonmanager_CQUI.lua</File>
-    <File>Assets/UI/WorldView/plotinfo_CQUI.lua</File>
-    <File>Assets/UI/WorldView/plotinfo.xml</File>
-    <File>Integrations/BTS/UI/tradeoverview.xml</File>
-    <File>Integrations/BTS/UI/tradeoverview.lua</File>
-    <File>Integrations/BTS/UI/tradesupport.lua</File>
-    <File>Integrations/BTS/UI/Choosers/traderoutechooser.xml</File>
-    <File>Integrations/BTS/UI/Choosers/traderoutechooser.lua</File>
-    <File>Integrations/BTS/UI/Choosers/tradeoriginchooser.xml</File>
-    <File>Integrations/BTS/UI/Choosers/tradeoriginchooser.lua</File>
-    <File>Integrations/BTS/Text/bts_text.xml</File>
-    <File>Integrations/BTS/Text/bts_text_de.xml</File>
-    <File>Integrations/BTS/Text/bts_text_es.xml</File>
-    <File>Integrations/BTS/Text/bts_text_fr.xml</File>
-    <File>Integrations/BTS/Text/bts_text_it.xml</File>
-    <File>Integrations/BTS/Text/bts_text_ja.xml</File>
-    <File>Integrations/BTS/Text/bts_text_ko.xml</File>
-    <File>Integrations/BTS/Text/bts_text_pl.xml</File>
-    <File>Integrations/BTS/Text/bts_text_pt.xml</File>
-    <File>Integrations/BTS/Text/bts_text_ru.xml</File>
-    <File>Integrations/BTS/Text/bts_text_zh.xml</File>
-    <File>Integrations/URS/reportscreen.lua</File>
-    <File>Integrations/URS/reportscreen.xml</File>
-    <File>Integrations/URS/unitpromotionpopup.lua</File>
-    <File>Integrations/URS/Text/urs_text.xml</File>
-    <File>Integrations/URS/Text/urs_text_de.xml</File>
-    <File>Integrations/URS/Text/urs_text_es.xml</File>
-    <File>Integrations/URS/Text/urs_text_fr.xml</File>
-    <File>Integrations/URS/Text/urs_text_it.xml</File>
-    <File>Integrations/URS/Text/urs_text_ja.xml</File>
-    <File>Integrations/URS/Text/urs_text_ko.xml</File>
-    <File>Integrations/URS/Text/urs_text_pl.xml</File>
-    <File>Integrations/URS/Text/urs_text_pt.xml</File>
-    <File>Integrations/URS/Text/urs_text_ru.xml</File>
-    <File>Integrations/URS/Text/urs_text_zh.xml</File>
-    <!--<File>Integrations/IDS/diplomacydealview.lua</File>
-    <File>Integrations/IDS/diplomacydealview.xml</File>-->
-    <File>Integrations/IDS/Text/ids_text.xml</File>
-    <File>Integrations/IDS/Text/ids_text_de.xml</File>
-    <File>Integrations/IDS/Text/ids_text_es.xml</File>
-    <File>Integrations/IDS/Text/ids_text_fr.xml</File>
-    <File>Integrations/IDS/Text/ids_text_it.xml</File>
-    <File>Integrations/IDS/Text/ids_text_ja.xml</File>
-    <File>Integrations/IDS/Text/ids_text_ko.xml</File>
-    <File>Integrations/IDS/Text/ids_text_pl.xml</File>
-    <File>Integrations/IDS/Text/ids_text_pt.xml</File>
-    <File>Integrations/IDS/Text/ids_text_ru.xml</File>
-    <File>Integrations/IDS/Text/ids_text_zh.xml</File>
-    <File>Integrations/ML/Text/morelenses_text.xml</File>
-    <File>Integrations/ML/Text/morelenses_text_de.xml</File>
-    <File>Integrations/ML/Text/morelenses_text_es.xml</File>
-    <File>Integrations/ML/Text/morelenses_text_fr.xml</File>
-    <File>Integrations/ML/Text/morelenses_text_it.xml</File>
-    <File>Integrations/ML/Text/morelenses_text_ja.xml</File>
-    <File>Integrations/ML/Text/morelenses_text_ko.xml</File>
-    <File>Integrations/ML/Text/morelenses_text_pl.xml</File>
-    <File>Integrations/ML/Text/morelenses_text_pt.xml</File>
-    <File>Integrations/ML/Text/morelenses_text_ru.xml</File>
-    <File>Integrations/ML/Text/morelenses_text_zh.xml</File>
-    <File>Integrations/ML/UI/minimappanel.lua</File>
-    <File>Integrations/ML/UI/minimappanel.xml</File>
-    <File>Integrations/ML/UI/Panels/modallenspanel.lua</File>
-    <File>Integrations/ML/UI/Panels/modallenspanel.xml</File>
-    <File>Integrations/ML/morelenses_colors.sql</File>
-    <File>Integrations/ML/Lenses/LensSupport.lua</File>
-    <File>Integrations/ML/Lenses/ModLens_Builder.lua</File>
-    <File>Integrations/ML/Lenses/ModLens_Builder_Config_Default.lua</File>
-    <File>Integrations/ML/Lenses/ModLens_Scout.lua</File>
-    <File>Integrations/ML/Lenses/ModLens_Archaeologist.lua</File>
-    <File>Integrations/ML/Lenses/ModLens_Barbarian.lua</File>
-    <File>Integrations/ML/Lenses/ModLens_Naturalist.lua</File>
-    <File>Integrations/ML/Lenses/ModLens_Wonder.lua</File>
-    <File>Integrations/ML/Lenses/ModLens_CitizenManagement.lua</File>
-    <File>Integrations/ML/Lenses/ModLens_CityOverlap.xml</File>
-    <File>Integrations/ML/Lenses/ModLens_CityOverlap.lua</File>
-    <File>Integrations/ML/Lenses/ModLens_Resource.xml</File>
-    <File>Integrations/ML/Lenses/ModLens_Resource.lua</File>
-    <File>Integrations/ML/DLC/Expansion1/UI/Replacements/MinimapPanel.xml</File>
-    <File>Integrations/ML/DLC/Expansion2/UI/Replacements/MinimapPanel.xml</File>
-    <File>Integrations/BES/UI/espionagesupport.lua</File>
-    <File>Integrations/BES/UI/Choosers/espionagechooser.lua</File>
-    <File>Integrations/BES/UI/Choosers/espionagechooser.xml</File>
-    <File>Integrations/BES/UI/PartialScreens/espionageoverview.lua</File>
-    <File>Integrations/BES/UI/PartialScreens/espionageoverview.xml</File>
-    <File>Integrations/BES/Text/bes_text.xml</File>
-    <File>Integrations/BES/Text/bes_text_de.xml</File>
-    <File>Integrations/BES/Text/bes_text_es.xml</File>
-    <File>Integrations/BES/Text/bes_text_fr.xml</File>
-    <File>Integrations/BES/Text/bes_text_it.xml</File>
-    <File>Integrations/BES/Text/bes_text_ja.xml</File>
-    <File>Integrations/BES/Text/bes_text_pt.xml</File>
-    <File>Integrations/BES/Text/bes_text_ru.xml</File>
-  </Files>
-
+  <!-- ============================== Action Criteria ============================== -->
   <ActionCriteria>
     <Criteria id="Expansion1">
       <GameCoreInUse>Expansion1</GameCoreInUse>
@@ -294,7 +51,53 @@
     </Criteria>
   </ActionCriteria>
 
-  <Components>
+  <InGameActions>
+   <!-- LoadOrder 0 is default, we need this to load first -->
+   <!-- 0 is where most actions are applied.  -100 is for Schema changes, and just ensuring early loads are caught -->
+   <!-- This table can be found in the Documentation included with the SDK.  It exists as a poorly formatted markdown table. -->
+   <!-- |Value      |Description|
+        |-100       |Schema changes
+                     Remove Data
+                     Populate core data| 
+        |-75        |Unofficial Schema changes|
+        |-50        |Premature Updates 
+                     Updates that need to be made before content is typically added.|
+        |-25        |Unofficial changes to premature updates|
+        |0          |Standard Content Updates
+                     Most actions applied during this phase.|
+        |25         |Unofficial changes to standard updates| 
+        |50         |Post Updates
+                     Updates that require most content to be provided.|
+        |75         |Unofficial changes to post-update content| 
+        |100        |Scenario Updates
+                     Often applied at the very end of everything else. Called out as its own phase.|
+        |125        |Unofficial changes to Scenario updates.|
+    -->
+
+    <!-- ============================== CQUI specific settings ============================== -->
+    <UpdateDatabase id="CQUI_Settings">
+       <Properties>
+        <Name>CQUI Settings</Name>
+        <LoadOrder>-100</LoadOrder>
+      </Properties>
+      <Items>
+        <File>Assets/cqui_databaseschema.sql</File>
+        <File>Assets/cqui_settings.sql</File>
+        <File>Assets/cqui_settings_local.sql</File>
+      </Items>
+    </UpdateDatabase>
+
+    <!-- The CQUICommon file is referenced by the Civ6Common file replacement.-->
+    <!-- The LoadOrder of this file needs to be after the Database Schema changes, but before everything else in the mod -->
+    <ImportFiles id="CQUI_IMPORT_COMMON_FILES">
+      <Properties>
+        <LoadOrder>-75</LoadOrder>
+      </Properties>
+      <Items>
+        <File>Assets/UI/CQUICommon.lua</File>
+      </Items>
+    </ImportFiles>
+
     <ImportFiles id="CQUI_IMPORT_FILES">
       <Items>
         <File>Assets/Texture/CQUI_GreatPeople_Background_Bottom.dds</File>
@@ -302,8 +105,8 @@
         <File>Assets/Texture/CQUI_GreatPeople_Background_Repeat_Top.dds</File>
         <File>Assets/Texture/CQUI_GreatPeople_Background_Top.dds</File>
         <File>Assets/UI/actionpanel.lua</File>
-        <File>Assets/UI/citysupport.lua</File>
         <File>Assets/UI/civ6common.lua</File>
+        <File>Assets/UI/citysupport.lua</File>
         <File>Assets/UI/diplomacyactionview_CQUI_basegame.lua</File>
         <File>Assets/UI/diplomacyactionview_CQUI.lua</File>
         <File>Assets/UI/diplomacyactionview.xml</File>
@@ -365,10 +168,11 @@
       </Items>
     </ImportFiles>
 
-    <!-- CQUI Expansion 1 (Rise and Fall) files -->
+    <!-- ============================== CQUI Expansion 1 (Rise and Fall) files ============================== -->
     <ImportFiles id="CQUI_EXP1_IMPORT_FILES" criteria="Expansion1">
       <Properties>
         <LoadOrder>100</LoadOrder>
+        <!-- <LoadOrder>110</LoadOrder> -->
         <Context>InGame</Context>
       </Properties>
       <Items>
@@ -388,7 +192,7 @@
       </Items>
     </ImportFiles>
 
-    <!-- CQUI Expansion 1 and beyond files -->
+    <!--==============================  CQUI Expansion 1 and beyond files ============================== -->
     <ImportFiles id="CQUI_EXP1BEYOND_IMPORT_FILES" criteria="Expansion1AndBeyond">
       <Properties>
         <LoadOrder>150</LoadOrder>
@@ -402,7 +206,7 @@
       </Items>
     </ImportFiles>
 
-    <!-- CQUI Expansion 2 (Gathering Storm) files -->
+    <!-- ============================== CQUI Expansion 2 (Gathering Storm) files ======================================== -->
     <ImportFiles id="CQUI_EXP2_IMPORT_FILES" criteria="Expansion2">
       <Properties>
         <LoadOrder>200</LoadOrder>
@@ -430,7 +234,7 @@
       </Items>
     </ImportFiles>
 
-    <!-- CQUI specific LOCs  -->
+    <!-- ============================== CQUI specific LOCs ============================== -->
     <LocalizedText id="CQUI_TEXT">
       <Items>
         <File>Assets/Text/Gossip_Text.xml</File>
@@ -464,44 +268,39 @@
       </Items>
     </LocalizedText>
 
-    <!-- CQUI specific settings -->
-    <UpdateDatabase id="CQUI_Settings">
-      <Properties>
-        <Name>CQUI Settings</Name>
-      </Properties>
-      <Items>
-        <File>Assets/cqui_databaseschema.sql</File>
-        <File>Assets/cqui_settings.sql</File>
-        <File>Assets/cqui_settings_local.sql</File>
-      </Items>
-    </UpdateDatabase>
-
-    <!-- CQUI specific UIs -->
-    <UserInterface id="CQUI_UI">
+    <!-- ============================== CQUI specific UIs ============================== -->
+    <AddUserInterfaces id="CQUI_UI">
       <Properties>
         <Context>InGame</Context>
+        <LoadOrder>11</LoadOrder>
       </Properties>
       <Items>
         <File>Assets/cqui_settingselement.xml</File>
+        <!-- <File>Assets/cqui_settingselement.lua</File> --> <!-- implied load -->
         <File>Assets/cqui_toplayer.xml</File>
         <File>Assets/UI/Popups/policyreminderpopup.xml</File>
         <!--the lua files are taken as implied-->
       </Items>
-    </UserInterface>
+    </AddUserInterfaces>
 
-    <!-- CQUI specific scripts -->
+    <!-- ==============================  CQUI specific scripts ============================== -->
+    <!-- NOTE: Is this declaration necessary any longer? -->
+    <!--       If so, note that if we require additional instances, we need separete GamePlayScripts entries -->
+    <!--       As the importer does not honor multiple entires listed in the Items/File section. -->
     <GameplayScripts id="CQUI_SCRIPTS">
       <Items>
         <File>Assets/cqui_main.lua</File>
       </Items>
     </GameplayScripts>
 
-    <!-- CQUI specific art overrides -->
+    <!-- ============================== CQUI specific art overrides ============================== -->
     <ModArt id="CQUI_MODART">
       <Items>
         <File>cqui.dep</File>
       </Items>
     </ModArt>
+
+    <!-- ============================== ReplaceUIScript Declarations ============================== -->
 
     <ReplaceUIScript id="CQUI_DiplomacyActionView">
       <Properties>
@@ -775,8 +574,8 @@
       </Properties>
     </ReplaceUIScript>
 
-    <!-- Mod integrations -->
-    <!-- BTS -->
+    <!-- ============================== Mod integrations ======================================== -->
+    <!-- ============================== Better Trade Screen (BTS) ============================== -->
     <LocalizedText id="BTS_TEXT">
       <Items>
         <File>Integrations/BTS/Text/bts_text.xml</File>
@@ -803,10 +602,11 @@
         <File>Integrations/BTS/UI/Choosers/tradeoriginchooser.lua</File>
       </Items>
     </ImportFiles>
-    <!-- End of BTS -->
 
-    <!-- UNITREPORT -->
-    <!-- <ImportFiles id="UNITREPORT_IMPORT_FILES">
+    <!-- ============================== UNITREPORT ============================== -->
+    <! -- UnitReport was commented out prior to May 2020 patch -->
+    <!--
+      <ImportFiles id="UNITREPORT_IMPORT_FILES">
       <Properties>
         <LoadOrder>-10</LoadOrder>
         <Context>InGame</Context>
@@ -841,9 +641,11 @@
         <File>Integrations/URS/Text/urs_text_ru.xml</File>
         <File>Integrations/URS/Text/urs_text_zh.xml</File>
       </Items>
-    </LocalizedText> -->
+    </LocalizedText>
+    -->
 
-    <!-- IDS -->
+    <!-- ============================== Improved Diplomacy Screen (IDS) ============================== -->
+    <!-- The IDS_IMPORT_FILES were commented out prior to May 2020 patch -->
     <!-- <ImportFiles id="IDS_IMPORT_FILES">
       <Items>
         <File>Integrations/IDS/diplomacydealview.lua</File>
@@ -866,7 +668,7 @@
       </Items>
     </LocalizedText>
 
-    <!-- BES -->
+    <!-- ============================== Better Espionoge Screen (BES) ============================== -->
     <ImportFiles id="BES_IMPORT_FILES">
       <Items>
         <File>Integrations/BES/UI/espionagesupport.lua</File>
@@ -889,9 +691,8 @@
         <File>Integrations/BES/Text/bes_text_ru.xml</File>
       </Items>
     </LocalizedText>
-    <!-- End of BES -->
 
-    <!-- ML -->
+    <!-- ============================== MoreLenses (ML) ============================== -->
     <AddUserInterfaces id="MORELENSES_LENSES_WPANEL">
       <Properties>
         <Context>InGame</Context>
@@ -962,7 +763,6 @@
       </Items>
     </ImportFiles>
 
-
     <LocalizedText id="MORELENSES_TEXT">
       <Items>
         <File Priority="1">Integrations/ML/Text/morelenses_text.xml</File>
@@ -984,9 +784,256 @@
         <File>Integrations/ML/morelenses_colors.sql</File>
       </Items>
     </UpdateDatabase>
-    <!-- End of ML -->
-
-  </Components>
+    <!-- ============================== End of ML ============================== -->
+  <!-- </Components> -->
+  </InGameActions>
 
   <Settings />
+
+  <!-- Complete File Manifest -->
+  <Files>
+    <File>CQUI.dep</File>
+    <File>Assets/cqui_databaseschema.sql</File>
+    <File>Assets/cqui_settings.sql</File>
+    <File>Assets/cqui_settings_local.sql</File>
+    <File>Assets/cqui_settingselement.lua</File>
+    <File>Assets/cqui_settingselement.xml</File>
+    <File>Assets/cqui_main.lua</File>
+    <File>Assets/cqui_toplayer.xml</File>
+    <File>Assets/cqui_toplayer.lua</File>
+    <File>Assets/UI/CQUICommon.lua</File>
+    <File>Assets/UI/WTF.Lua</File>
+
+    <!-- EXP 1 -->
+    <File>Assets/Expansion1/CityBanners/citybannermanager.lua</File>
+    <File>Assets/Expansion1/CityBanners/citybannermanager.xml</File>
+    <File>Assets/Expansion1/CityBanners/citybannerinstances.xml</File>
+    <File>Assets/Expansion1/Replacements/citypanelculture_CQUI.lua</File>
+    <File>Assets/Expansion1/Replacements/citypaneloverview_expansion1_CQUI.lua</File>
+    <File>Assets/Expansion1/Replacements/citystates.xml</File>
+    <File>Assets/Expansion1/Replacements/citysupport.lua</File>
+    <File>Assets/Expansion1/Replacements/diplomacyactionview_CQUI_expansion1.lua</File>
+    <File>Assets/Expansion1/Replacements/governmentscreen_CQUI_expansion1.lua</File>
+    <File>Assets/Expansion1/Replacements/leadericon.lua</File>
+    <File>Assets/Expansion1/Replacements/leadericon.xml</File>
+    <File>Assets/Expansion1/Replacements/notificationpanel_CQUI_expansion1.lua</File>
+    <File>Assets/Expansion1/Replacements/partialscreenhooks_CQUI_expansion1.lua</File>
+    <File>Assets/Expansion1/Replacements/techtree_CQUI_expansion1.lua</File>
+    <File>Assets/Expansion1/Replacements/toppanel_CQUI_expansion1.lua</File>
+    <File>Assets/Expansion1/Replacements/unitpanel_CQUI_expansion1.lua</File>
+    <File>Assets/Expansion1/Replacements/worldtracker_expansion1.lua</File>
+
+    <!-- EXP 2 -->
+    <File>Assets/Expansion2/Replacements/citypaneloverview_expansion2_CQUI.lua</File>
+    <File>Assets/Expansion2/Replacements/citystates.xml</File>
+    <File>Assets/Expansion2/Replacements/citysupport.lua</File>
+    <File>Assets/Expansion2/Replacements/civicstree_CQUI_expansion2.lua</File>
+    <File>Assets/Expansion2/Replacements/diplomacyactionview_CQUI_expansion2.lua</File>
+    <File>Assets/Expansion2/Replacements/diplomacyactionview.xml</File>
+    <File>Assets/Expansion2/Replacements/diplomacydealview_CQUI_expansion2.lua</File>
+    <File>Assets/Expansion2/Replacements/diplomacyribbon.xml</File>
+    <File>Assets/Expansion2/Replacements/governmentscreen_CQUI_expansion2.lua</File>
+    <File>Assets/Expansion2/Replacements/ingame.lua</File>
+    <File>Assets/Expansion2/Replacements/notificationpanel_CQUI_expansion2.lua</File>
+    <File>Assets/Expansion2/Replacements/partialscreenhooks_CQUI_expansion2.lua</File>
+    <File>Assets/Expansion2/Replacements/plottooltip_CQUI_expansion2.lua</File>
+    <File>Assets/Expansion2/Replacements/techtree_CQUI_expansion2.lua</File>
+    <File>Assets/Expansion2/Replacements/toppanel_CQUI_expansion2.lua</File>
+    <File>Assets/Expansion2/Replacements/unitpanel_CQUI_expansion2.lua</File>
+    <File>Assets/Expansion2/CityBanners/citybannermanager.lua</File>
+    <File>Assets/Expansion2/CityBanners/citybannerinstances.xml</File>
+
+    <File>Integrations/URS/Expansion1/Replacements/reportscreen_expansion1.lua</File>
+    <File>Integrations/URS/Expansion1/Replacements/reportscreen.xml</File>
+    <File>Assets/Text/Gossip_Text.xml</File>
+    <File>Assets/Text/Gossip_Text_de.xml</File>
+    <File>Assets/Text/Gossip_Text_ja.xml</File>
+    <File>Assets/Text/Gossip_Text_pt.xml</File>
+    <File>Assets/Text/Gossip_Text_it.xml</File>
+    <File>Assets/Text/cqui_InGameText.xml</File>
+    <File>Assets/Text/cqui_InGameText_de.xml</File>
+    <File>Assets/Text/cqui_InGameText_ja.xml</File>
+    <File>Assets/Text/cqui_InGameText_it.xml</File>
+    <File>Assets/Text/cqui_text_general.xml</File>
+    <File>Assets/Text/cqui_text_general_de.xml</File>
+    <File>Assets/Text/cqui_text_general_es.xml</File>
+    <File>Assets/Text/cqui_text_general_fr.xml</File>
+    <File>Assets/Text/cqui_text_general_it.xml</File>
+    <File>Assets/Text/cqui_text_general_ja.xml</File>
+    <File>Assets/Text/cqui_text_general_ko.xml</File>
+    <File>Assets/Text/cqui_text_general_pl.xml</File>
+    <File>Assets/Text/cqui_text_general_pt.xml</File>
+    <File>Assets/Text/cqui_text_general_ru.xml</File>
+    <File>Assets/Text/cqui_text_general_zh.xml</File>
+    <File>Assets/Text/cqui_text_settings.xml</File>
+    <File>Assets/Text/cqui_text_settings_de.xml</File>
+    <File>Assets/Text/cqui_text_settings_es.xml</File>
+    <File>Assets/Text/cqui_text_settings_fr.xml</File>
+    <File>Assets/Text/cqui_text_settings_it.xml</File>
+    <File>Assets/Text/cqui_text_settings_ja.xml</File>
+    <File>Assets/Text/cqui_text_settings_ko.xml</File>
+    <File>Assets/Text/cqui_text_settings_pl.xml</File>
+    <File>Assets/Text/cqui_text_settings_pt.xml</File>
+    <File>Assets/Text/cqui_text_settings_ru.xml</File>
+    <File>Assets/Text/cqui_text_settings_zh.xml</File>
+    <File>Assets/Texture/CQUI_GreatPeople_Background_Bottom.dds</File>
+    <File>Assets/Texture/CQUI_GreatPeople_Background_Repeat_Bottom.dds</File>
+    <File>Assets/Texture/CQUI_GreatPeople_Background_Repeat_Top.dds</File>
+    <File>Assets/Texture/CQUI_GreatPeople_Background_Top.dds</File>
+    <File>Assets/UI/actionpanel.lua</File>
+    <File>Assets/UI/citysupport.lua</File>
+    <File>Assets/UI/civ6common.lua</File>
+    <File>Assets/UI/diplomacyactionview_CQUI_basegame.lua</File>
+    <File>Assets/UI/diplomacyactionview_CQUI.lua</File>
+    <File>Assets/UI/diplomacyactionview.xml</File>
+    <File>Assets/UI/diplomacydealview_CQUI_basegame.lua</File>
+    <File>Assets/UI/diplomacydealview_CQUI.lua</File>
+    <File>Assets/UI/diplomacydealview.xml</File>
+    <File>Assets/UI/diplomacyribbon.lua</File>
+    <File>Assets/UI/diplomacyribbon.xml</File>
+    <File>Assets/UI/ingame.lua</File>
+    <File>Assets/UI/launchbar.lua</File>
+    <File>Assets/UI/launchbar.xml</File>
+    <File>Assets/UI/leadericon.lua</File>
+    <File>Assets/UI/partialscreenhooks_CQUI_basegame.lua</File>
+    <File>Assets/UI/partialscreenhooks_CQUI.lua</File>
+    <File>Assets/UI/partialscreenhooks.xml</File>
+    <File>Assets/UI/productionpanel.xml</File>
+    <File>Assets/UI/supportfunctions.lua</File>
+    <File>Assets/UI/techandcivicsupport.lua</File>
+    <File>Assets/UI/toppanel_CQUI_basegame.lua</File>
+    <File>Assets/UI/toppanel_CQUI.lua</File>
+    <File>Assets/UI/unitflagmanager_CQUI.lua</File>
+    <File>Assets/UI/unitflagmanager.xml</File>
+    <File>Assets/UI/worldinput.lua</File>
+    <File>Assets/UI/worldtracker.lua</File>
+    <File>Assets/UI/worldtracker.xml</File>
+    <File>Assets/UI/worldviewiconsmanager_CQUI.lua</File>
+    <File>Assets/UI/Choosers/civicschooser.lua</File>
+    <File>Assets/UI/Choosers/researchchooser.lua</File>
+    <File>Assets/UI/Panels/citypanel.lua</File>
+    <File>Assets/UI/Panels/citypanel.xml</File>
+    <File>Assets/UI/Panels/citypaneloverview.lua</File>
+    <File>Assets/UI/Panels/citypaneloverview.xml</File>
+    <File>Assets/UI/Panels/notificationpanel_CQUI_basegame.lua</File>
+    <File>Assets/UI/Panels/notificationpanel_CQUI.lua</File>
+    <File>Assets/UI/Panels/productionpanel_CQUI.lua</File>
+    <File>Assets/UI/Panels/statusmessagepanel.lua</File>
+    <File>Assets/UI/Panels/statusmessagepanel.xml</File>
+    <File>Assets/UI/Panels/unitpanel_CQUI_basegame.lua</File>
+    <File>Assets/UI/Panels/unitpanel_CQUI.lua</File>
+    <File>Assets/UI/PartialScreens/citystates.lua</File>
+    <File>Assets/UI/PartialScreens/citystates.xml</File>
+    <File>Assets/UI/Popups/greatpeoplepopup.lua</File>
+    <File>Assets/UI/Popups/greatpeoplepopup.xml</File>
+    <File>Assets/UI/Popups/policyreminderpopup.lua</File>
+    <File>Assets/UI/Popups/policyreminderpopup.xml</File>
+    <File>Assets/UI/Popups/techciviccompletedpopup.lua</File>
+    <File>Assets/UI/Popups/wonderbuiltpopup_CQUI.lua</File>
+    <File>Assets/UI/Screens/civicstree_CQUI_basegame.lua</File>
+    <File>Assets/UI/Screens/civicstree_CQUI.lua</File>
+    <File>Assets/UI/Screens/governmentscreen_CQUI_basegame.lua</File>
+    <File>Assets/UI/Screens/governmentscreen_CQUI.lua</File>
+    <File>Assets/UI/Screens/techtree_CQUI_basegame.lua</File>
+    <File>Assets/UI/Screens/techtree_CQUI.lua</File>
+    <File>Assets/UI/ToolTips/plottooltip_CQUI_basegame.lua</File>
+    <File>Assets/UI/ToolTips/plottooltip_CQUI.lua</File>
+    <File>Assets/UI/Utilities/extendedrelationship.lua</File>
+    <File>Assets/UI/WorldView/citybannermanager.lua</File>
+    <File>Assets/UI/WorldView/citybannermanager.xml</File>
+    <File>Assets/UI/WorldView/districtploticonmanager_CQUI.lua</File>
+    <File>Assets/UI/WorldView/plotinfo_CQUI.lua</File>
+    <File>Assets/UI/WorldView/plotinfo.xml</File>
+    <File>Integrations/BTS/UI/tradeoverview.xml</File>
+    <File>Integrations/BTS/UI/tradeoverview.lua</File>
+    <File>Integrations/BTS/UI/tradesupport.lua</File>
+    <File>Integrations/BTS/UI/Choosers/traderoutechooser.xml</File>
+    <File>Integrations/BTS/UI/Choosers/traderoutechooser.lua</File>
+    <File>Integrations/BTS/UI/Choosers/tradeoriginchooser.xml</File>
+    <File>Integrations/BTS/UI/Choosers/tradeoriginchooser.lua</File>
+    <File>Integrations/BTS/Text/bts_text.xml</File>
+    <File>Integrations/BTS/Text/bts_text_de.xml</File>
+    <File>Integrations/BTS/Text/bts_text_es.xml</File>
+    <File>Integrations/BTS/Text/bts_text_fr.xml</File>
+    <File>Integrations/BTS/Text/bts_text_it.xml</File>
+    <File>Integrations/BTS/Text/bts_text_ja.xml</File>
+    <File>Integrations/BTS/Text/bts_text_ko.xml</File>
+    <File>Integrations/BTS/Text/bts_text_pl.xml</File>
+    <File>Integrations/BTS/Text/bts_text_pt.xml</File>
+    <File>Integrations/BTS/Text/bts_text_ru.xml</File>
+    <File>Integrations/BTS/Text/bts_text_zh.xml</File>
+    <File>Integrations/URS/reportscreen.lua</File>
+    <File>Integrations/URS/reportscreen.xml</File>
+    <File>Integrations/URS/unitpromotionpopup.lua</File>
+    <File>Integrations/URS/Text/urs_text.xml</File>
+    <File>Integrations/URS/Text/urs_text_de.xml</File>
+    <File>Integrations/URS/Text/urs_text_es.xml</File>
+    <File>Integrations/URS/Text/urs_text_fr.xml</File>
+    <File>Integrations/URS/Text/urs_text_it.xml</File>
+    <File>Integrations/URS/Text/urs_text_ja.xml</File>
+    <File>Integrations/URS/Text/urs_text_ko.xml</File>
+    <File>Integrations/URS/Text/urs_text_pl.xml</File>
+    <File>Integrations/URS/Text/urs_text_pt.xml</File>
+    <File>Integrations/URS/Text/urs_text_ru.xml</File>
+    <File>Integrations/URS/Text/urs_text_zh.xml</File>
+    <File>Integrations/IDS/Text/ids_text.xml</File>
+    <File>Integrations/IDS/Text/ids_text_de.xml</File>
+    <File>Integrations/IDS/Text/ids_text_es.xml</File>
+    <File>Integrations/IDS/Text/ids_text_fr.xml</File>
+    <File>Integrations/IDS/Text/ids_text_it.xml</File>
+    <File>Integrations/IDS/Text/ids_text_ja.xml</File>
+    <File>Integrations/IDS/Text/ids_text_ko.xml</File>
+    <File>Integrations/IDS/Text/ids_text_pl.xml</File>
+    <File>Integrations/IDS/Text/ids_text_pt.xml</File>
+    <File>Integrations/IDS/Text/ids_text_ru.xml</File>
+    <File>Integrations/IDS/Text/ids_text_zh.xml</File>
+    <File>Integrations/ML/Text/morelenses_text.xml</File>
+    <File>Integrations/ML/Text/morelenses_text_de.xml</File>
+    <File>Integrations/ML/Text/morelenses_text_es.xml</File>
+    <File>Integrations/ML/Text/morelenses_text_fr.xml</File>
+    <File>Integrations/ML/Text/morelenses_text_it.xml</File>
+    <File>Integrations/ML/Text/morelenses_text_ja.xml</File>
+    <File>Integrations/ML/Text/morelenses_text_ko.xml</File>
+    <File>Integrations/ML/Text/morelenses_text_pl.xml</File>
+    <File>Integrations/ML/Text/morelenses_text_pt.xml</File>
+    <File>Integrations/ML/Text/morelenses_text_ru.xml</File>
+    <File>Integrations/ML/Text/morelenses_text_zh.xml</File>
+    <File>Integrations/ML/UI/minimappanel.lua</File>
+    <File>Integrations/ML/UI/minimappanel.xml</File>
+    <File>Integrations/ML/UI/Panels/modallenspanel.lua</File>
+    <File>Integrations/ML/UI/Panels/modallenspanel.xml</File>
+    <File>Integrations/ML/morelenses_colors.sql</File>
+    <File>Integrations/ML/Lenses/LensSupport.lua</File>
+    <File>Integrations/ML/Lenses/ModLens_Builder.lua</File>
+    <File>Integrations/ML/Lenses/ModLens_Builder_Config_Default.lua</File>
+    <File>Integrations/ML/Lenses/ModLens_Scout.lua</File>
+    <File>Integrations/ML/Lenses/ModLens_Archaeologist.lua</File>
+    <File>Integrations/ML/Lenses/ModLens_Barbarian.lua</File>
+    <File>Integrations/ML/Lenses/ModLens_Naturalist.lua</File>
+    <File>Integrations/ML/Lenses/ModLens_Wonder.lua</File>
+    <File>Integrations/ML/Lenses/ModLens_CitizenManagement.lua</File>
+    <File>Integrations/ML/Lenses/ModLens_CityOverlap.xml</File>
+    <File>Integrations/ML/Lenses/ModLens_CityOverlap.lua</File>
+    <File>Integrations/ML/Lenses/ModLens_Resource.xml</File>
+    <File>Integrations/ML/Lenses/ModLens_Resource.lua</File>
+    <File>Integrations/ML/DLC/Expansion1/UI/Replacements/MinimapPanel.xml</File>
+    <File>Integrations/ML/DLC/Expansion2/UI/Replacements/MinimapPanel.xml</File>
+    <File>Integrations/BES/UI/espionagesupport.lua</File>
+    <File>Integrations/BES/UI/Choosers/espionagechooser.lua</File>
+    <File>Integrations/BES/UI/Choosers/espionagechooser.xml</File>
+    <File>Integrations/BES/UI/PartialScreens/espionageoverview.lua</File>
+    <File>Integrations/BES/UI/PartialScreens/espionageoverview.xml</File>
+    <File>Integrations/BES/Text/bes_text.xml</File>
+    <File>Integrations/BES/Text/bes_text_de.xml</File>
+    <File>Integrations/BES/Text/bes_text_es.xml</File>
+    <File>Integrations/BES/Text/bes_text_fr.xml</File>
+    <File>Integrations/BES/Text/bes_text_it.xml</File>
+    <File>Integrations/BES/Text/bes_text_ja.xml</File>
+    <File>Integrations/BES/Text/bes_text_pt.xml</File>
+    <File>Integrations/BES/Text/bes_text_ru.xml</File>
+
+    <!-- These two files were commented out Before May 2020 Patch -->
+    <!--<File>Integrations/IDS/diplomacydealview.lua</File>
+    <File>Integrations/IDS/diplomacydealview.xml</File>-->
+  </Files>
 </Mod>

--- a/Integrations/ML/UI/minimappanel.lua
+++ b/Integrations/ML/UI/minimappanel.lua
@@ -4,7 +4,6 @@ include( "InstanceManager" );
 -- ===========================================================================
 --  MODDED LENS (by Astog)
 -- ===========================================================================
-
 g_ModLenses = {} -- Populated by ModLens_*.lua scripts
 include( "ModLens_", true )
 
@@ -35,7 +34,6 @@ g_shouldCloseLensMenu = true;    -- Controls when the Lens menu should be closed
 g_ContinentsCache = {};
 
 g_HexColoringContinent = UILens.CreateLensLayerHash("Hex_Coloring_Continent");
-
 
 -- ===========================================================================
 --  MEMBERS
@@ -116,8 +114,6 @@ function CloseAllFlyouts()
     else
       UI.DataError("Minimap's CloseAllFlyouts() attempted to unselect'"..buttonId.."' but the control doesn't exist in the XML.");
     end
-
-
   end
 end
 
@@ -225,6 +221,7 @@ function OnToggleLensList()
   end
 end
 
+-- ===========================================================
 function CloseLensList()
   g_shouldCloseLensMenu = true;
   Controls.ReligionLensButton:SetCheck(false);
@@ -236,8 +233,7 @@ function CloseLensList()
   Controls.TourismLensButton:SetCheck(false);
   Controls.EmpireLensButton:SetCheck(false);
 
-  -- Astog
-  --------------------------------------------------------------------------------------------------
+  -- Begin Astog Mod --------------------------------------------------------------------------------------------------
   -- Turn off each mod lens
   local i = 1
   local lensButtonInstance = m_LensButtonIM:GetAllocatedInstance(i)
@@ -249,7 +245,7 @@ function CloseLensList()
 
   -- Hide each panel that exist for lens
   LuaEvents.ML_CloseLensPanels()
-  --------------------------------------------------------------------------------------------------
+  -- End Astog Mod ------------------------------------------------------------------------------------------------
 
   local uiCurrInterfaceMode:number = UI.GetInterfaceMode();
   if uiCurrInterfaceMode == InterfaceModeTypes.VIEW_MODAL_LENS then
@@ -335,8 +331,7 @@ end
 function ToggleAppealLens()
   if Controls.AppealLensButton:IsChecked() then
 
-    -- Astog
-    --------------------------------------------------------------------------------------------------
+    -- Begin Astog Mod --------------------------------------------------------------------------------------------------
     SetActiveModdedLens("VANILLA_APPEAL");
 
     -- Check if the appeal lens is already active. Needed to clear any modded lens
@@ -344,7 +339,7 @@ function ToggleAppealLens()
       -- Unapply the appeal lens, so it can be cleared from the screen
       UILens.SetActive("Default");
     end
-    --------------------------------------------------------------------------------------------------
+    -- End Astog Mod ------------------------------------------------------------------------------------------------
 
     UILens.SetActive("Appeal");
     RefreshInterfaceMode();
@@ -506,8 +501,7 @@ end
 -- ===========================================================================
 function OnLensLayerOn( layerNum:number )
 
-  -- Astog
-  --------------------------------------------------------------------------------------------------
+  -- Begin Astog Mod --------------------------------------------------------------------------------------------------
   -- clear unit non-standard layers
   -- do this if no unit is selected, since these lenses are applied on unit selection, so control should be in SelectedUnit.lua
   if UI.GetHeadSelectedUnit() == nil then
@@ -519,14 +513,13 @@ function OnLensLayerOn( layerNum:number )
     UILens.ClearLayerHexes(m_HexColoringGreatPeople);
     UILens.ClearLayerHexes(m_MovementZoneOfControl);
   end
-  --------------------------------------------------------------------------------------------------
+  -- End Astog Mod ------------------------------------------------------------------------------------------------
 
   if layerNum == m_HexColoringReligion then
     UI.PlaySound("UI_Lens_Overlay_On");
     UILens.SetDesaturation(1.0);
 
-    -- Astog
-    --------------------------------------------------------------------------------------------------
+  -- Begin Astog Mod --------------------------------------------------------------------------------------------------
   elseif layerNum == m_HexColoringAppeal then
     if m_CurrentModdedLensOn == "VANILLA_APPEAL" then
       SetAppealHexes();
@@ -534,7 +527,7 @@ function OnLensLayerOn( layerNum:number )
       SetModLens();
     end
     UI.PlaySound("UI_Lens_Overlay_On");
-    --------------------------------------------------------------------------------------------------
+  -- End Astog Mod ------------------------------------------------------------------------------------------------
 
   elseif layerNum == m_HexColoringGovernment then
     SetGovernmentHexes();
@@ -555,9 +548,7 @@ end
 
 -- ===========================================================================
 function OnLensLayerOff( layerNum:number )
-
-  -- Astog
-  --------------------------------------------------------------------------------------------------
+  -- Begin Astog Modification  --------------------------------------------------------------------------------------------------
   -- clear unit non-standard layers
   -- do this if no unit is selected, since these lenses are applied on unit selection, so control should be in SelectedUnit.lua
   if UI.GetHeadSelectedUnit() == nil then
@@ -584,7 +575,7 @@ function OnLensLayerOff( layerNum:number )
       UILens.ClearLayerHexes(m_HexColoringAppeal);
     end
     UI.PlaySound("UI_Lens_Overlay_Off");
-    --------------------------------------------------------------------------------------------------
+    -- End Astog Modification ------------------------------------------------------------------------------------------------
 
   elseif layerNum == m_HexColoringWaterAvail then
     -- Only clear the water lens if we're turning off lenses altogether, but not if switching to another modal lens (Turning on another modal lens clears it already).
@@ -626,9 +617,7 @@ end
 
 -- ===========================================================================
 function OnUserOptionsActivated()
-
   RestoreYieldIcons();
-
 end
 
 -- ===========================================================================
@@ -653,7 +642,6 @@ function SetOwningCivHexes()
 end
 
 -- ===========================================================================
-
 function SetDefaultWaterHexes()
   local FullWaterPlots:table = {};
   local CoastalWaterPlots:table = {};
@@ -683,9 +671,7 @@ function SetDefaultWaterHexes()
   end
 end
 
-
--- Astog
---------------------------------------------------------------------------------------------------
+-- Begin Astog --------------------------------------------------------------------------------------------------
 function SetWaterHexes()
   if (not m_CtrlDown) then
     print("default")
@@ -767,6 +753,7 @@ function SetSettlerLens()
   end
 end
 
+-- ===========================================================
 function RefreshSettlerLens()
   UILens.ClearLayerHexes(m_HexColoringWaterAvail)
   SetWaterHexes()
@@ -787,7 +774,7 @@ function RecheckSettlerLens()
     UILens.ToggleLayerOff( m_HexColoringWaterAvail );
   end
 end
---------------------------------------------------------------------------------------------------
+-- End Astog Update ------------------------------------------------------------------------------------------------
 
 -- ===========================================================================
 function SetGovernmentHexes()
@@ -1010,9 +997,9 @@ function OnInterfaceModeChanged(eOldMode:number, eNewMode:number)
       LuaEvents.ML_CloseLensPanels()
     end
   end
-
 end
 
+-- ===========================================================
 function GetMinimapMouseCoords( mousex:number, mousey:number )
   local topLeftX, topLeftY = Controls.MinimapImage:GetScreenOffset();
 
@@ -1029,6 +1016,7 @@ function IsMouseInMinimap( minix:number, miniy:number )
   return minix >= 0 and minix <= 1 and miniy >= 0 and miniy <= 1;
 end
 
+-- ===========================================================
 function TranslateMinimapToWorld( minix:number, miniy:number )
   local mapMinX, mapMinY, mapMaxX, mapMaxY = UI.GetMinimapWorldRect();
 
@@ -1043,11 +1031,11 @@ function TranslateMinimapToWorld( minix:number, miniy:number )
   return wx, wy;
 end
 
+-- ===========================================================
 function OnInputHandler( pInputStruct:table )
   local msg = pInputStruct:GetMessageType();
 
-  -- Astog
-  --------------------------------------------------------------------------------------------------
+  -- Astog Modification Begin -------------------------------------------------
   if pInputStruct:GetKey() == Keys.VK_CONTROL then
     if msg == KeyEvents.KeyDown then
       if not m_AltSettlerLensOn and UILens.IsLayerOn(m_HexColoringWaterAvail) then
@@ -1063,7 +1051,7 @@ function OnInputHandler( pInputStruct:table )
   end
 
   HandleMouseForModdedLens()
-  --------------------------------------------------------------------------------------------------
+  -- Astog Modification End ---------------------------------------------------
 
   -- Catch ctrl+f
   if pInputStruct:GetKey() == Keys.F and pInputStruct:IsControlDown() then
@@ -1115,6 +1103,7 @@ function OnInputHandler( pInputStruct:table )
         local wx, wy = TranslateMinimapToWorld( minix, miniy );
         UI.FocusMap( wx, wy );
       end
+
       m_wasMouseInMinimap = isMouseInMinimap
       return isMouseInMinimap; -- Only consume event if it's inside the minimap.
 
@@ -1171,7 +1160,7 @@ function OnInputHandler( pInputStruct:table )
   return false;
 end
 
-
+-- ===========================================================
 function OnTutorial_DisableMapDrag( isDisabled:boolean )
   m_isMouseDragEnabled = not isDisabled;
   if isDisabled then
@@ -1181,10 +1170,12 @@ function OnTutorial_DisableMapDrag( isDisabled:boolean )
   end
 end
 
+-- ===========================================================
 function OnTutorial_SwitchToWorldView()
   Controls.SwitcherImage:SetTextureOffsetVal(0,0);
 end
 
+-- ===========================================================
 function OnShutdown()
   LuaEvents.Tutorial_SwitchToWorldView.Remove( OnTutorial_SwitchToWorldView );
   LuaEvents.Tutorial_DisableMapDrag.Remove( OnTutorial_DisableMapDrag );
@@ -1217,13 +1208,14 @@ function SetModLens()
     elseif funNonStandard ~= nil then
       funNonStandard()
     else
-      print("ERROR: No Plot Color Function")
+      print("ERROR: SetModLens - No Plot Color Function")
     end
   else
-    print("ERROR: Given lens has no entry")
+    print("ERROR: SetModLens - Given lens has no entry")
   end
 end
 
+-- ===========================================================================
 function SetModLensHexes(colorPlot:table)
   if colorPlot ~= nil and table.count(colorPlot) > 0 then
     -- UILens.ClearLayerHexes(m_HexColoringAppeal);
@@ -1235,28 +1227,33 @@ function SetModLensHexes(colorPlot:table)
       end
     end
   else
-    print("ERROR: Invalid colorPlot table")
+    print("ERROR: SetModLensHexes - Invalid colorPlot table")
   end
 end
 
+-- ===========================================================================
 function SetActiveModdedLens(lensName:string)
   m_CurrentModdedLensOn = lensName
   LuaEvents.MinimapPanel_ModdedLensOn(lensName)
 end
 
+-- ===========================================================================
 function GetActiveModdedLens(returnLens:table)
   returnLens[1] = m_CurrentModdedLensOn
 end
 
+-- ===========================================================================
 function GetLensPanelOffsets(offsets:table)
   local y = Controls.MinimapContainer:GetSizeY() + Controls.MinimapContainer:GetOffsetY()
   if m_isCollapsed then
     y = y - Controls.MinimapContainer:GetSizeY()
   end
+
   offsets.Y = y
   offsets.X = Controls.LensPanel:GetSizeX() + Controls.LensPanel:GetOffsetX()
 end
 
+-- ===========================================================================
 function ToggleModLens(buttonControl:table, lensName:string)
   if buttonControl:IsChecked() then
     SetActiveModdedLens(lensName);
@@ -1272,6 +1269,7 @@ function ToggleModLens(buttonControl:table, lensName:string)
       -- print("Toggling....")
       g_ModLenses[lensName].OnToggle()
     end
+
     UILens.SetActive("Appeal");
     RefreshInterfaceMode();
   else
@@ -1279,13 +1277,15 @@ function ToggleModLens(buttonControl:table, lensName:string)
     if UI.GetInterfaceMode() == InterfaceModeTypes.VIEW_MODAL_LENS then
       UI.SetInterfaceMode(InterfaceModeTypes.SELECTION);
     end
+
     LuaEvents.ML_CloseLensPanels()
     SetActiveModdedLens("NONE");
   end
 end
 
+-- ===========================================================================
 function InitLens(lensName, modLens)
-  print("Adding ModLens: " .. lensName)
+  print("InitLens - Adding ModLens: " .. lensName)
   if modLens.Initialize ~= nil then
     modLens.Initialize()
   end
@@ -1297,17 +1297,19 @@ function InitLens(lensName, modLens)
   pLensButton:LocalizeAndSetText(modLens.LensButtonText)
   modLensToggle.LensButton:SetToolTipString(pToolTip)
   modLensToggle.LensButton:RegisterCallback(Mouse.eLClick,
-  function()
-    ToggleModLens(modLensToggle.LensButton, lensName);
-  end
-  )
+    function()
+      ToggleModLens(modLensToggle.LensButton, lensName);
+    end
+    )
 end
 
+-- ===========================================================================
 function AddLensEntry(lensKey:string, lensEntry:table)
   g_ModLenses[lensKey] = lensEntry
   InitLens(lensKey, lensEntry)
 end
 
+-- ===========================================================================
 function InitializeModLens()
   print("Initializing " .. table.count(g_ModLenses) .. " lenses")
   -- sort here
@@ -1315,6 +1317,7 @@ function InitializeModLens()
   for lensName, modLens in pairs(g_ModLenses) do
     table.insert(sortedModLenses, { SortOrder = modLens.SortOrder, Name = lensName, Lens = modLens } )
   end
+
   table.sort(sortedModLenses, function(a,b) return (a.SortOrder and a.SortOrder or 999) < (b.SortOrder and b.SortOrder or 999) end)
   -- initilize sorted
   for _,modLens in ipairs(sortedModLenses) do
@@ -1322,6 +1325,7 @@ function InitializeModLens()
   end
 end
 
+-- ===========================================================================
 function HandleMouseForModdedLens()
   if not m_isMouseDragging then
     LuaEvents.ML_HandleMouse()
@@ -1359,6 +1363,7 @@ end
 
 -- ===========================================================================
 function LateInitialize()
+  print_debug("ENTRY: Replacement MinimapPanel - LateInitialize");
   m_MiniMap_xmloffsety = Controls.MiniMap:GetOffsetY();
   g_ContinentsCache = Map.GetContinentsInUse();
 
@@ -1386,6 +1391,7 @@ function LateInitialize()
   Controls.ExpandButton:RegisterCallback( Mouse.eLClick, OnCollapseToggle );
   Controls.ExpandButton:RegisterCallback( Mouse.eMouseEnter, function() UI.PlaySound("Main_Menu_Mouse_Over"); end);
   Controls.GovernmentLensButton:RegisterCallback( Mouse.eLClick, ToggleGovernmentLens );
+
   if GameConfiguration.IsWorldBuilderEditor() then
     Controls.MapPinListButton:SetDisabled(true);
     Controls.MapPinListButton:SetHide(true);
@@ -1413,6 +1419,7 @@ function LateInitialize()
     Controls.ToggleResourcesButton:SetHide(false);
     Controls.ToggleYieldsButton:SetHide(false);
   end
+
   Controls.MapOptionsButton:RegisterCallback( Mouse.eLClick, ToggleMapOptionsList );
   Controls.MapOptionsButton:RegisterCallback( Mouse.eMouseEnter, function() UI.PlaySound("Main_Menu_Mouse_Over"); end);
   Controls.MapOptionsButton:SetHide(false);
@@ -1430,6 +1437,16 @@ function LateInitialize()
   Controls.ToggleYieldsButton:RegisterCallback( Mouse.eLClick, ToggleYieldIcons );
   Controls.WaterLensButton:RegisterCallback( Mouse.eLClick, ToggleWaterLens );
 
+  -- Begin CQUI Mod ------------------------------------------------------------------------------------
+  -- Requires the CQUI Database and CQUICommon files have been loaded before this (<LoadOrder>)
+  -- CQUI Options Button
+  Controls.CQUI_OptionsButton:RegisterCallback( Mouse.eLClick, function() LuaEvents.CQUI_ToggleSettings() end);
+  Controls.CQUI_OptionsButton:RegisterCallback( Mouse.eMouseEnter, function() UI.PlaySound("Main_Menu_Mouse_Over"); end)  
+  -- CQUI Handlers
+  LuaEvents.CQUI_Option_ToggleYields.Add( ToggleYieldIcons );
+  LuaEvents.CQUI_SettingsInitialized.Add( CQUI_ToggleYieldIcons );
+  -- End CQUI Mod ------------------------------------------------------------------------------------
+
   -- Game Events
   Events.InputActionTriggered.Add( OnInputActionTriggered );
   Events.InterfaceModeChanged.Add( OnInterfaceModeChanged );
@@ -1439,7 +1456,6 @@ function LateInitialize()
   Events.UserOptionsActivated.Add( OnUserOptionsActivated );
 
   Events.CityAddedToMap.Add( OnCityAddedToMap );
-
 end
 
 -- ===========================================================================
@@ -1447,6 +1463,7 @@ function OnInit( isReload:boolean )
   LateInitialize();
 end
 
+-- ===========================================================
 function CloseAllLenses()
   if not Controls.LensPanel:IsHidden() then
     OnToggleLensList();
@@ -1457,7 +1474,7 @@ end
 -- INITIALIZATION
 -- ===========================================================================
 function Initialize()
-
+  print_debug("ENTRY: Replacement MinimapPanel - Initialize");
   ContextPtr:SetInitHandler( OnInit );
   ContextPtr:SetInputHandler( OnInputHandler, true );
 
@@ -1473,15 +1490,6 @@ function Initialize()
     Controls.StrategicSwitcherButton:SetHide(true);
     Controls.OptionsStack:ReprocessAnchoring();
   end
-
-  -- CQUI Options Button
-  Controls.CQUI_OptionsButton:RegisterCallback( Mouse.eLClick, function() LuaEvents.CQUI_ToggleSettings() end);
-  Controls.CQUI_OptionsButton:RegisterCallback( Mouse.eMouseEnter, function() UI.PlaySound("Main_Menu_Mouse_Over"); end);
-
-  -- CQUI Handlers
-  LuaEvents.CQUI_Option_ToggleYields.Add( ToggleYieldIcons );
-  LuaEvents.CQUI_SettingsInitialized.Add( CQUI_ToggleYieldIcons );
-
 
   -- Make sure the StrategicSwitcherButton has the correct image when the game starts in StrategicView
   if UI.GetWorldRenderView() == WorldRenderView.VIEW_2D then
@@ -1500,8 +1508,7 @@ function Initialize()
     end
   end );
 
-  -- Astog
-  --------------------------------------------------------------------------------------------------
+  -- Begin Astog Mod --------------------------------------------------------------------------------------------------
 
   -- Mod Lens Support
   LuaEvents.MinimapPanel_SetActiveModLens.Add( SetActiveModdedLens );
@@ -1510,6 +1517,6 @@ function Initialize()
   LuaEvents.MinimapPanel_AddLensEntry.Add( AddLensEntry );
   InitializeModLens()
 
-  --------------------------------------------------------------------------------------------------
+  -- End Astog Mod ------------------------------------------------------------------------------------------------
 end
 Initialize();


### PR DESCRIPTION
Cleanup work intended as part of making updates required by future patches easier to deal with:
 - ModInfo file:
   - Use currently supported XML elements (InGameActions, AddUserInterfaces, etc.)
   - Move File Manifest to end of file
   - Add LoadOrder values for Database modification and new CQUICommon
 - Civ6Common.lua:
  - Moved CQUI-specific logic to CQUICommon.lua (now has include of this file)
  - Clearly marked differences between this replacement file and the base Civ6Common.lua
- CQUICommon.lua
  - All CQUI-specific logic previously in Civ6Common.lua moved here
- CQUI_SettingsElement.lua:
  - Code formatting for readability
- MinimapPanel.lua:
  - Code formatting for readability intend to do future work to clearly separate out Mod code
  - TODO: Integrate current changes to the ModLenses released on Steam Workshop on 5/23
