### PR TITLE
Fixed StatusMsg Offset and Extra Builder in Lens

### DIFF
--- a/Assets/UI/Panels/statusmessagepanel.xml
+++ b/Assets/UI/Panels/statusmessagepanel.xml
@@ -3,7 +3,9 @@
 <Context Name="StatusMessagePanel" >
 
   <Container Size="parent,parent">
-    <Stack ID="StackOfMessages" Anchor="C,T" StackGrowth="Bottom" Offset="0,120"/>
+  <!-- CQUI: Adjusting Offset to account for expanded Diplomacy Ribbon (Y-size is 163 in Vanilla, 180 in Gathering Storm) -->
+  <!-- CQUI: Original OffsetY value was 120 -->
+    <Stack ID="StackOfMessages" Anchor="C,T" StackGrowth="Bottom" Offset="0,210"/>
   </Container>
 
   <Instance             Name="StatusMessageInstance">

--- a/Integrations/ML/UI/minimappanel.lua
+++ b/Integrations/ML/UI/minimappanel.lua
@@ -1060,6 +1060,12 @@ function InitLens(lensName, modLens)
     modLens.Initialize()
   end
 
+  if lensName == 'CQUI_CITIZEN_MANAGEMENT' then
+    -- Skip over this one, it is the lens showing when clicking on a city.
+    -- This lens should not be included in the list of lenses off the Minimap panel
+    return
+  end
+
   -- Add this lens to button stack
   local modLensToggle = m_LensButtonIM:GetInstance();
   local pLensButton = modLensToggle.LensButton:GetTextButton()


### PR DESCRIPTION
- Status/Gossip messages now appear below the Diplomacy Ribbon (previously overlayed or appeared behind it).
- Lens options (from Minimap panel) no longer includes extra "Builder" lens that appears to do nothing (this was actually the lens shown when clicking on a city and does not need to be in that list).
